### PR TITLE
🎨 Palette: Add aria-labels to icon-only buttons in HabitSection

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-21 - Icon-Only Button Accessibility Pattern
+**Learning:** Found that multiple icon-only action buttons across components (like HabitSection) lack aria-labels, making them completely opaque to screen readers despite having title attributes (which are insufficient for accessibility).
+**Action:** Always add descriptive `aria-label`s to any button that uses icons without accompanying visible text, especially for repeated lists of action icons (like Edit/Delete).

--- a/src/components/HabitSection.tsx
+++ b/src/components/HabitSection.tsx
@@ -220,7 +220,11 @@ export default function HabitSection({ selectedDate }: HabitSectionProps) {
                             className="bg-transparent border-none text-sm text-white focus:ring-0 w-full py-1.5 placeholder-gray-500"
                             autoFocus
                         />
-                        <button onClick={() => { setShowSearch(false); setSearchQuery(''); }} className="text-gray-400 hover:text-white">
+                        <button
+                            onClick={() => { setShowSearch(false); setSearchQuery(''); }}
+                            className="text-gray-400 hover:text-white"
+                            aria-label="Close search"
+                        >
                             <X className="w-3 h-3" />
                         </button>
                     </div>
@@ -233,6 +237,7 @@ export default function HabitSection({ selectedDate }: HabitSectionProps) {
                 onClick={() => setHideWeekends(!hideWeekends)} 
                 className={`p-2 rounded transition-colors ${hideWeekends ? 'bg-blue-600/20 text-blue-400' : 'hover:bg-[#232323] text-gray-400'}`} 
                 title={hideWeekends ? "Show Weekends" : "Hide Weekends"}
+                aria-label={hideWeekends ? "Show Weekends" : "Hide Weekends"}
               >
                 <Filter className="w-4 h-4" />
               </button>
@@ -241,6 +246,7 @@ export default function HabitSection({ selectedDate }: HabitSectionProps) {
                 onClick={() => setSortOrder(prev => prev === 'default' ? 'name' : 'default')}
                 className={`p-2 rounded transition-colors ${sortOrder === 'name' ? 'bg-blue-600/20 text-blue-400' : 'hover:bg-[#232323] text-gray-400'}`}
                 title="Sort by Name"
+                aria-label="Sort by Name"
               >
                 <ArrowUpDown className="w-4 h-4" />
               </button>
@@ -249,6 +255,7 @@ export default function HabitSection({ selectedDate }: HabitSectionProps) {
                 onClick={completeAllForToday} 
                 className="p-2 hover:bg-[#232323] rounded transition-colors text-gray-400 hover:text-yellow-400" 
                 title="Complete All for Today"
+                aria-label="Complete All for Today"
               >
                 <Zap className="w-4 h-4" />
               </button>
@@ -257,6 +264,7 @@ export default function HabitSection({ selectedDate }: HabitSectionProps) {
                 onClick={() => setShowSearch(true)} 
                 className={`p-2 rounded transition-colors ${showSearch ? 'bg-blue-600/20 text-blue-400' : 'hover:bg-[#232323] text-gray-400'}`}
                 title="Search"
+                aria-label="Search habits"
               >
                 <Search className="w-4 h-4" />
               </button>
@@ -265,11 +273,12 @@ export default function HabitSection({ selectedDate }: HabitSectionProps) {
                 onClick={() => setIsMaximized(!isMaximized)} 
                 className={`p-2 rounded transition-colors ${isMaximized ? 'bg-blue-600/20 text-blue-400' : 'hover:bg-[#232323] text-gray-400'}`}
                 title={isMaximized ? "Minimize" : "Maximize"}
+                aria-label={isMaximized ? "Minimize habit view" : "Maximize habit view"}
               >
                 {isMaximized ? <Minimize2 className="w-4 h-4" /> : <Maximize2 className="w-4 h-4" />}
               </button>
 
-              <button className="p-2 hover:bg-[#232323] rounded transition-colors" title="Settings">
+              <button className="p-2 hover:bg-[#232323] rounded transition-colors" title="Settings" aria-label="Habit settings">
                 <Settings className="w-4 h-4 text-gray-400" />
               </button>
 
@@ -343,8 +352,8 @@ export default function HabitSection({ selectedDate }: HabitSectionProps) {
                                 <span className="truncate max-w-[100px]" title={habit.name}>{habit.name}</span>
                             </div>
                             <div className="opacity-0 group-hover:opacity-100 flex gap-1 absolute right-2 bg-[#1a1a1a] p-1 rounded-md shadow-sm border border-[#333] z-20">
-                                <button onClick={() => { setEditingHabit(habit); setFormData({...habit}); setShowForm(true); }} className="hover:text-blue-400 p-1"><Edit2 className="w-3 h-3"/></button>
-                                <button onClick={() => deleteHabit(habit.id)} className="hover:text-red-400 p-1"><Trash2 className="w-3 h-3"/></button>
+                                <button onClick={() => { setEditingHabit(habit); setFormData({...habit}); setShowForm(true); }} className="hover:text-blue-400 p-1" aria-label="Edit habit"><Edit2 className="w-3 h-3"/></button>
+                                <button onClick={() => deleteHabit(habit.id)} className="hover:text-red-400 p-1" aria-label="Delete habit"><Trash2 className="w-3 h-3"/></button>
                             </div>
                         </div>
                     </th>


### PR DESCRIPTION
💡 **What:** Added descriptive `aria-label` attributes to multiple icon-only action buttons in the `HabitSection.tsx` component (e.g., search, hide weekends, settings, edit, and delete). Also added an entry to `.Jules/palette.md` noting the missing aria-label pattern.
🎯 **Why:** To ensure that screen readers can properly interpret and announce the function of these interactive elements, making the application significantly more accessible for users with visual impairments.
♿ **Accessibility:** Solves a critical accessibility issue where icon-only buttons without text were entirely opaque to screen readers despite having `title` attributes.

---
*PR created automatically by Jules for task [3755083455992933735](https://jules.google.com/task/3755083455992933735) started by @aryankumar06*