### PR TITLE
🎨 Palette: [UX improvement] - Added aria-labels to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-28 - ARIA labels for Icon-Only buttons
+**Learning:** Icon-only buttons often lack accessible names, making them difficult for screen reader users to understand.
+**Action:** Always ensure icon-only buttons have an `aria-label` attribute describing their action.

--- a/src/components/HabitSection.tsx
+++ b/src/components/HabitSection.tsx
@@ -220,7 +220,7 @@ export default function HabitSection({ selectedDate }: HabitSectionProps) {
                             className="bg-transparent border-none text-sm text-white focus:ring-0 w-full py-1.5 placeholder-gray-500"
                             autoFocus
                         />
-                        <button onClick={() => { setShowSearch(false); setSearchQuery(''); }} className="text-gray-400 hover:text-white">
+                        <button onClick={() => { setShowSearch(false); setSearchQuery(''); }} className="text-gray-400 hover:text-white" aria-label="Close search">
                             <X className="w-3 h-3" />
                         </button>
                     </div>
@@ -233,6 +233,7 @@ export default function HabitSection({ selectedDate }: HabitSectionProps) {
                 onClick={() => setHideWeekends(!hideWeekends)} 
                 className={`p-2 rounded transition-colors ${hideWeekends ? 'bg-blue-600/20 text-blue-400' : 'hover:bg-[#232323] text-gray-400'}`} 
                 title={hideWeekends ? "Show Weekends" : "Hide Weekends"}
+                aria-label={hideWeekends ? "Show Weekends" : "Hide Weekends"}
               >
                 <Filter className="w-4 h-4" />
               </button>
@@ -241,6 +242,7 @@ export default function HabitSection({ selectedDate }: HabitSectionProps) {
                 onClick={() => setSortOrder(prev => prev === 'default' ? 'name' : 'default')}
                 className={`p-2 rounded transition-colors ${sortOrder === 'name' ? 'bg-blue-600/20 text-blue-400' : 'hover:bg-[#232323] text-gray-400'}`}
                 title="Sort by Name"
+                aria-label="Sort by Name"
               >
                 <ArrowUpDown className="w-4 h-4" />
               </button>
@@ -249,6 +251,7 @@ export default function HabitSection({ selectedDate }: HabitSectionProps) {
                 onClick={completeAllForToday} 
                 className="p-2 hover:bg-[#232323] rounded transition-colors text-gray-400 hover:text-yellow-400" 
                 title="Complete All for Today"
+                aria-label="Complete All for Today"
               >
                 <Zap className="w-4 h-4" />
               </button>
@@ -257,6 +260,7 @@ export default function HabitSection({ selectedDate }: HabitSectionProps) {
                 onClick={() => setShowSearch(true)} 
                 className={`p-2 rounded transition-colors ${showSearch ? 'bg-blue-600/20 text-blue-400' : 'hover:bg-[#232323] text-gray-400'}`}
                 title="Search"
+                aria-label="Search"
               >
                 <Search className="w-4 h-4" />
               </button>
@@ -265,11 +269,12 @@ export default function HabitSection({ selectedDate }: HabitSectionProps) {
                 onClick={() => setIsMaximized(!isMaximized)} 
                 className={`p-2 rounded transition-colors ${isMaximized ? 'bg-blue-600/20 text-blue-400' : 'hover:bg-[#232323] text-gray-400'}`}
                 title={isMaximized ? "Minimize" : "Maximize"}
+                aria-label={isMaximized ? "Minimize" : "Maximize"}
               >
                 {isMaximized ? <Minimize2 className="w-4 h-4" /> : <Maximize2 className="w-4 h-4" />}
               </button>
 
-              <button className="p-2 hover:bg-[#232323] rounded transition-colors" title="Settings">
+              <button className="p-2 hover:bg-[#232323] rounded transition-colors" title="Settings" aria-label="Settings">
                 <Settings className="w-4 h-4 text-gray-400" />
               </button>
 
@@ -343,8 +348,8 @@ export default function HabitSection({ selectedDate }: HabitSectionProps) {
                                 <span className="truncate max-w-[100px]" title={habit.name}>{habit.name}</span>
                             </div>
                             <div className="opacity-0 group-hover:opacity-100 flex gap-1 absolute right-2 bg-[#1a1a1a] p-1 rounded-md shadow-sm border border-[#333] z-20">
-                                <button onClick={() => { setEditingHabit(habit); setFormData({...habit}); setShowForm(true); }} className="hover:text-blue-400 p-1"><Edit2 className="w-3 h-3"/></button>
-                                <button onClick={() => deleteHabit(habit.id)} className="hover:text-red-400 p-1"><Trash2 className="w-3 h-3"/></button>
+                                <button onClick={() => { setEditingHabit(habit); setFormData({...habit}); setShowForm(true); }} className="hover:text-blue-400 p-1" aria-label="Edit habit"><Edit2 className="w-3 h-3"/></button>
+                                <button onClick={() => deleteHabit(habit.id)} className="hover:text-red-400 p-1" aria-label="Delete habit"><Trash2 className="w-3 h-3"/></button>
                             </div>
                         </div>
                     </th>

--- a/src/components/InboxView.tsx
+++ b/src/components/InboxView.tsx
@@ -401,6 +401,7 @@ export default function InboxView() {
                                     <button 
                                         onClick={() => deleteNotification(notification.id)}
                                         className="text-gray-400 hover:text-red-500 opacity-0 group-hover:opacity-100 transition-opacity"
+                                        aria-label="Delete notification"
                                     >
                                         <Trash2 className="w-4 h-4" />
                                     </button>

--- a/src/components/WorkspaceView.tsx
+++ b/src/components/WorkspaceView.tsx
@@ -646,6 +646,7 @@ export default function WorkspaceView() {
                                             <button 
                                                 onClick={() => handleRemoveMember(m.id, m.user_id)}
                                                 className="ml-1 text-gray-400 hover:text-red-500"
+                                                aria-label="Remove member"
                                             >
                                                 <X className="w-3 h-3" />
                                             </button>
@@ -936,7 +937,7 @@ function Modal({ onClose, title, children }: ModalProps) {
             <div className="bg-white dark:bg-neutral-900 w-full max-w-md rounded-2xl shadow-xl border border-gray-200 dark:border-neutral-800">
                 <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-neutral-800">
                     <h3 className="text-lg font-bold dark:text-white">{title}</h3>
-                    <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+                    <button onClick={onClose} className="text-gray-400 hover:text-gray-600" aria-label="Close modal">
                         <X className="w-5 h-5" />
                     </button>
                 </div>
@@ -977,6 +978,7 @@ function TaskCard({ task, role, isManager, getMemberName, onUpdateStatus, onDele
                     <button 
                         onClick={() => onDelete(task.id)}
                         className="text-gray-400 hover:text-red-500 opacity-0 group-hover:opacity-100 transition-opacity"
+                        aria-label="Delete task"
                     >
                         <Trash2 className="w-4 h-4" />
                     </button>


### PR DESCRIPTION
💡 What: Added aria-label attributes to icon-only buttons in multiple components.
🎯 Why: Without aria-labels, screen reader users cannot determine the functionality of buttons that only contain an icon (like Close, Search, Filter, Delete, Edit).
📸 Before/After: Visuals remain unchanged, but screen readers will now announce the button functionality properly.
♿ Accessibility: Ensures that interactive elements have a discernible name, conforming to WCAG standards.

---
*PR created automatically by Jules for task [14157045965754550743](https://jules.google.com/task/14157045965754550743) started by @aryankumar06*