### PR TITLE
🎨 Palette: Improve accessibility of habit checkboxes

### DIFF
--- a/src/components/HabitSection.tsx
+++ b/src/components/HabitSection.tsx
@@ -379,6 +379,7 @@ export default function HabitSection({ selectedDate }: HabitSectionProps) {
                                  checked={isCompleted(habit.id, date)}
                                  onCheckedChange={() => toggleCompletion(habit.id, date)}
                                  className="border-gray-600 data-[state=checked]:bg-blue-600 data-[state=checked]:border-blue-600"
+                                 aria-label={`Toggle ${habit.name} on ${format(date, 'MMM d')}`}
                              />
                             </div>
                         </td>


### PR DESCRIPTION
💡 **What:** Added `aria-label` to the habit toggle checkbox inside `src/components/HabitSection.tsx`.
🎯 **Why:** In a data grid of checkboxes, screen readers cannot intrinsically associate the column headers (dates) and row headers (habit names) with the input. By providing `aria-label={"Toggle [Habit] on [Date]"}`, users relying on assistive technology have full context on the action they are performing.
♿ **Accessibility:** Greatly improves the usability of the Habit tracker for screen reader users by removing ambiguity around unlabelled checkbox toggles in a matrix.

---
*PR created automatically by Jules for task [15324773373378571914](https://jules.google.com/task/15324773373378571914) started by @aryankumar06*