### PR TITLE
🎨 Palette: Add explicit aria-labels to habit checkboxes

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-03-24 - Data Grid Checkbox Context
+**Learning:** Screen readers lack context when navigating standard checkboxes within tables/data grids, making it hard for users to know what they are toggling.
+**Action:** Always provide explicit row and column context in the `aria-label` for inputs in data grids.

--- a/src/components/HabitSection.tsx
+++ b/src/components/HabitSection.tsx
@@ -376,6 +376,7 @@ export default function HabitSection({ selectedDate }: HabitSectionProps) {
                         <td key={`${habit.id}-${date}`} className="px-6 py-4 border-r border-[#2a2a2a]">
                             <div className="flex justify-start">
                              <Checkbox 
+                                 aria-label={`Toggle ${habit.name} on ${dayName}`}
                                  checked={isCompleted(habit.id, date)}
                                  onCheckedChange={() => toggleCompletion(habit.id, date)}
                                  className="border-gray-600 data-[state=checked]:bg-blue-600 data-[state=checked]:border-blue-600"


### PR DESCRIPTION
💡 What: Added `aria-label` to the habit toggle checkboxes in `HabitSection.tsx`.
🎯 Why: Without explicit row and column context, screen readers can't identify what a checkbox in a data grid is for.
📸 Before/After: Accessibility enhancement.
♿ Accessibility: Provides explicit context (e.g. "Toggle Workout on Monday") for screen readers navigating the habits data grid.

---
*PR created automatically by Jules for task [4611162066169125386](https://jules.google.com/task/4611162066169125386) started by @aryankumar06*