### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/src/components/RequestFeatureForm.tsx
+++ b/src/components/RequestFeatureForm.tsx
@@ -87,6 +87,7 @@ export function RequestFeatureForm({ className, variant = 'default' }: RequestFe
                                     Request a Feature
                                 </h2>
                                 <button 
+                                    aria-label="Close modal"
                                     onClick={() => setIsOpen(false)}
                                     className="p-2 hover:bg-neutral-100 dark:hover:bg-neutral-800 rounded-full transition-colors text-neutral-500"
                                 >

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -179,6 +179,7 @@ export default function SettingsView() {
                                 </p>
                             </div>
                             <button 
+                                aria-label="Copy code"
                                 onClick={() => {
                                     if (userCode) {
                                         navigator.clipboard.writeText(userCode);

--- a/src/components/WorkspaceView.tsx
+++ b/src/components/WorkspaceView.tsx
@@ -567,6 +567,7 @@ export default function WorkspaceView() {
                             <div className="flex items-center gap-2">
                                 {/* Back button for mobile */}
                                 <button
+                                    aria-label="Back to workspaces"
                                     onClick={() => setActiveWorkspaceId(null)}
                                     className="md:hidden p-2 hover:bg-gray-200 dark:hover:bg-neutral-700 rounded-lg transition-colors"
                                     title="Back to workspaces"
@@ -644,6 +645,7 @@ export default function WorkspaceView() {
                                         </span>
                                         {canManageMembers && m.user_id !== user?.id && (
                                             <button 
+                                                aria-label="Remove member"
                                                 onClick={() => handleRemoveMember(m.id, m.user_id)}
                                                 className="ml-1 text-gray-400 hover:text-red-500"
                                             >


### PR DESCRIPTION
💡 **What:** Added `aria-label` attributes to multiple icon-only buttons across the app.
🎯 **Why:** To improve accessibility for screen reader users who previously would not know the function of these buttons since they lack visible text.
♿ **Accessibility:** Added explicit contexts like "Back to workspaces", "Remove member", "Copy code", and "Close modal" to buttons that only contained `ChevronRight`, `X`, or `Copy` icons.

---
*PR created automatically by Jules for task [5908319681247592785](https://jules.google.com/task/5908319681247592785) started by @aryankumar06*