### PR TITLE
🎨 Palette: Add explicit aria-labels to habit checkboxes

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-03 - [Data Grid Accessibility]
+**Learning:** When using checkboxes or inputs within a data grid (like a habit tracker calendar), explicit row and column context must be provided in the `aria-label` (e.g., `aria-label="Toggle [Row] on [Column]"`) so screen readers can properly announce the context. Without this, users only hear "checkbox", leaving them unsure which item and date they are interacting with.
+**Action:** Always construct a detailed `aria-label` string utilizing both the row identifier (e.g., item name) and column identifier (e.g., formatted date) for any interactive elements inside table cells or CSS grids.

--- a/src/components/HabitSection.tsx
+++ b/src/components/HabitSection.tsx
@@ -379,6 +379,7 @@ export default function HabitSection({ selectedDate }: HabitSectionProps) {
                                  checked={isCompleted(habit.id, date)}
                                  onCheckedChange={() => toggleCompletion(habit.id, date)}
                                  className="border-gray-600 data-[state=checked]:bg-blue-600 data-[state=checked]:border-blue-600"
+                                 aria-label={`Toggle ${habit.name} on ${format(date, 'MMM d, yyyy')}`}
                              />
                             </div>
                         </td>


### PR DESCRIPTION
💡 What: Added an explicit `aria-label` to the `Checkbox` component in the habit tracker grid.
🎯 Why: Without this explicit label, screen readers only read "checkbox" for every cell in the grid, leaving users completely blind to which habit and date they are modifying. By adding "Toggle [Habit Name] on [Date]", users now have full context.
♿ Accessibility: Major screen reader experience improvement for the main data grid interaction.

---
*PR created automatically by Jules for task [16565983637771819215](https://jules.google.com/task/16565983637771819215) started by @aryankumar06*