### PR TITLE
🎨 Palette: Add contextual ARIA labels and focus states to Plan lists

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-15 - Explicit Context in Data Grid Checkboxes
 **Learning:** Checkboxes within a data grid without explicit context in their aria-label can be confusing for screen reader users as they lack spatial context.
 **Action:** When using checkboxes within a data grid, always provide explicit row and column context in the aria-label (e.g., `aria-label="Toggle [Row] on [Column]"`) so screen readers can announce the context.
+
+## 2024-05-16 - Contextual Action Buttons in Hierarchical Lists
+**Learning:** Icon-only action buttons (like Delete or Expand) in nested lists without item-specific context in their aria-label confuse screen reader users. They hear "Delete" multiple times without knowing what they are deleting.
+**Action:** When adding actions to list or tree items, always include the item's title in the aria-label (e.g., `aria-label={`Delete task: ${task.title}`}`) to provide explicit context.

--- a/src/components/ui/agent-plan.tsx
+++ b/src/components/ui/agent-plan.tsx
@@ -242,7 +242,8 @@ export default function Plan() {
                   {hasChildren && (
                     <button
                       onClick={() => toggleExpand(project.id)}
-                      className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+                      aria-label={isExpanded ? `Collapse project: ${project.title}` : `Expand project: ${project.title}`}
+                      className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 focus-visible:ring-2 focus-visible:ring-blue-500 outline-none rounded"
                     >
                       {isExpanded ? <ChevronDown className="w-5 h-5" /> : <ChevronRight className="w-5 h-5" />}
                     </button>
@@ -251,7 +252,8 @@ export default function Plan() {
                   {/* Status Icon - Animated */}
                   <motion.button
                     onClick={() => toggleStatus(project.id, project.status)}
-                    className="flex-shrink-0 hover:opacity-80 transition-opacity"
+                    aria-label={`Toggle status for project: ${project.title}`}
+                    className="flex-shrink-0 hover:opacity-80 transition-opacity focus-visible:ring-2 focus-visible:ring-blue-500 outline-none rounded-full"
                   >
                     <AnimatePresence mode="wait">
                       <motion.div
@@ -297,7 +299,8 @@ export default function Plan() {
                   {/* Delete Button */}
                   <button
                     onClick={() => deleteItem(project.id)}
-                    className="p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-md transition-colors"
+                    aria-label={`Delete project: ${project.title}`}
+                    className="p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-md transition-colors focus-visible:ring-2 focus-visible:ring-blue-500 outline-none"
                     title="Delete project"
                   >
                     <Trash2 className="w-4 h-4" />
@@ -372,7 +375,8 @@ export default function Plan() {
                               {hasSubtasks && (
                                 <button
                                   onClick={() => toggleExpand(task.id)}
-                                  className="text-gray-400 hover:text-gray-600"
+                                  aria-label={isTaskExpanded ? `Collapse task: ${task.title}` : `Expand task: ${task.title}`}
+                                  className="text-gray-400 hover:text-gray-600 focus-visible:ring-2 focus-visible:ring-blue-500 outline-none rounded"
                                 >
                                   {isTaskExpanded ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
                                 </button>
@@ -381,7 +385,8 @@ export default function Plan() {
                               {/* Status Icon - Animated */}
                               <motion.button
                                 onClick={() => toggleStatus(task.id, task.status)}
-                                className="flex-shrink-0 hover:opacity-80 transition-opacity"
+                                aria-label={`Toggle status for task: ${task.title}`}
+                                className="flex-shrink-0 hover:opacity-80 transition-opacity focus-visible:ring-2 focus-visible:ring-blue-500 outline-none rounded-full"
                               >
                                 <AnimatePresence mode="wait">
                                   <motion.div
@@ -415,7 +420,8 @@ export default function Plan() {
                               {/* Delete Button */}
                               <button
                                 onClick={() => deleteItem(task.id)}
-                                className="p-1.5 text-gray-400 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-md transition-colors"
+                                aria-label={`Delete task: ${task.title}`}
+                                className="p-1.5 text-gray-400 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-md transition-colors focus-visible:ring-2 focus-visible:ring-blue-500 outline-none"
                                 title="Delete task"
                               >
                                 <Trash2 className="w-3.5 h-3.5" />
@@ -483,7 +489,8 @@ export default function Plan() {
                                     <div key={subtask.id} className="flex items-center gap-3 py-1">
                                       <motion.button
                                         onClick={() => toggleStatus(subtask.id, subtask.status)}
-                                        className="flex-shrink-0 hover:opacity-80 transition-opacity"
+                                        aria-label={`Toggle status for subtask: ${subtask.title}`}
+                                        className="flex-shrink-0 hover:opacity-80 transition-opacity focus-visible:ring-2 focus-visible:ring-blue-500 outline-none rounded-full"
                                       >
                                         <AnimatePresence mode="wait">
                                           <motion.div
@@ -512,7 +519,8 @@ export default function Plan() {
                                       </span>
                                       <button
                                         onClick={() => deleteItem(subtask.id)}
-                                        className="p-1 text-gray-400 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-md transition-colors"
+                                        aria-label={`Delete subtask: ${subtask.title}`}
+                                        className="p-1 text-gray-400 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-md transition-colors focus-visible:ring-2 focus-visible:ring-blue-500 outline-none"
                                         title="Delete subtask"
                                       >
                                         <Trash2 className="w-3 h-3" />


### PR DESCRIPTION
This PR improves the UX and Accessibility of the nested lists in `agent-plan.tsx`.

It ensures that:
1. Every icon-only button (expand/collapse, status toggle, delete) has an explicitly contextual `aria-label` that includes the item's title (e.g., "Delete task: Make wireframes").
2. Every interactive button gets a consistent, accessible keyboard focus outline using `focus-visible:ring-2 focus-visible:ring-blue-500`.

These changes greatly enhance usability for screen reader and keyboard-only users without affecting the visual layout. I have also added an entry to `.Jules/palette.md` for this learning.

---
*PR created automatically by Jules for task [6767622918182628878](https://jules.google.com/task/6767622918182628878) started by @aryankumar06*