### PR TITLE
🎨 Palette: Dynamic context for icon-only action buttons

### DIFF
--- a/src/components/EventSection.tsx
+++ b/src/components/EventSection.tsx
@@ -225,12 +225,14 @@ export default function EventSection({ selectedDate }: EventSectionProps) {
                   <button
                     onClick={() => handleEdit(event)}
                     className="p-2 text-gray-400 dark:text-gray-500 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-blue-50 dark:hover:bg-neutral-800 rounded transition-colors"
+                    aria-label={`Edit event: ${event.title}`}
                   >
                     <Edit2 className="w-4 h-4" />
                   </button>
                   <button
                     onClick={() => handleDelete(event.id)}
                     className="p-2 text-gray-400 dark:text-gray-500 hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-neutral-800 rounded transition-colors"
+                    aria-label={`Delete event: ${event.title}`}
                   >
                     <Trash2 className="w-4 h-4" />
                   </button>

--- a/src/components/TaskSection.tsx
+++ b/src/components/TaskSection.tsx
@@ -688,14 +688,14 @@ function TaskItem({
           <button
             onClick={() => onEdit(task)}
             className="p-2 text-gray-400 dark:text-gray-500 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-blue-50 dark:hover:bg-neutral-800 rounded transition-colors"
-            aria-label="Edit task"
+            aria-label={`Edit task: ${task.title}`}
           >
             <Edit2 className="w-4 h-4" />
           </button>
           <button
             onClick={() => onDelete(task.id)}
             className="p-2 text-gray-400 dark:text-gray-500 hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-neutral-800 rounded transition-colors"
-            aria-label="Delete task"
+            aria-label={`Delete task: ${task.title}`}
           >
             <Trash2 className="w-4 h-4" />
           </button>

--- a/src/components/ui/task-plan.tsx
+++ b/src/components/ui/task-plan.tsx
@@ -177,6 +177,7 @@ export default function TaskPlan({
                       <button
                         onClick={() => toggleTaskExpansion(task.id)}
                         className="mr-1 p-0.5 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+                        aria-label={isExpanded ? `Collapse task: ${task.title}` : `Expand task: ${task.title}`}
                       >
                         {isExpanded ? (
                           <ChevronDown className="w-4 h-4" />


### PR DESCRIPTION
💡 **What**: Added dynamic ARIA labels to the "Edit" and "Delete" icon-only buttons in `TaskSection` and `EventSection`, and the expand/collapse button in the `task-plan` component.
🎯 **Why**: When multiple list items contain generic "Edit" or "Delete" actions without labels, a screen reader user only hears "Button, Edit" sequentially without knowing which item it refers to. Interpolating the item title directly into the `aria-label` provides immediate, unambiguous context (e.g., "Delete task: Buy Groceries").
📸 **Before/After**: N/A (Visually identical, purely an accessibility change)
♿ **Accessibility**: Considerably improves navigation and interaction confidence for screen reader users when managing tasks and events.

---
*PR created automatically by Jules for task [5138192274463098519](https://jules.google.com/task/5138192274463098519) started by @aryankumar06*