### PR TITLE
🎨 Palette: Add aria-label to delete notification button

### DIFF
--- a/src/components/InboxView.tsx
+++ b/src/components/InboxView.tsx
@@ -401,6 +401,7 @@ export default function InboxView() {
                                     <button 
                                         onClick={() => deleteNotification(notification.id)}
                                         className="text-gray-400 hover:text-red-500 opacity-0 group-hover:opacity-100 transition-opacity"
+                                        aria-label="Delete notification"
                                     >
                                         <Trash2 className="w-4 h-4" />
                                     </button>


### PR DESCRIPTION
* 💡 What: Added `aria-label="Delete notification"` to the icon-only delete button in `InboxView.tsx`.
* 🎯 Why: Icon-only buttons without accessible names are opaque to screen reader users, preventing them from understanding the button's action. This change ensures users using assistive technologies can identify the functionality of deleting a notification.
* 📸 Before/After: No visual change.
* ♿ Accessibility: Improved screen reader experience by making the delete action explicitly discoverable through ARIA labels.

---
*PR created automatically by Jules for task [15788692854569345149](https://jules.google.com/task/15788692854569345149) started by @aryankumar06*