### PR TITLE
🎨 Palette: Explicit Context for Icon-Only Delete Buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-15 - Explicit Context in Data Grid Checkboxes
 **Learning:** Checkboxes within a data grid without explicit context in their aria-label can be confusing for screen reader users as they lack spatial context.
 **Action:** When using checkboxes within a data grid, always provide explicit row and column context in the aria-label (e.g., `aria-label="Toggle [Row] on [Column]"`) so screen readers can announce the context.
+
+## 2026-06-08 - Explicit Context for Icon-Only Action Buttons in Lists
+**Learning:** Icon-only action buttons (like Delete) in nested lists or trees without the item's context in the aria-label are ambiguous to screen reader users.
+**Action:** When adding icon-only action buttons to items in lists, always include the specific item's title in the `aria-label` (e.g., `aria-label="Delete task: [Task Title]"`) to provide explicit context.

--- a/src/components/EventSection.tsx
+++ b/src/components/EventSection.tsx
@@ -229,6 +229,7 @@ export default function EventSection({ selectedDate }: EventSectionProps) {
                     <Edit2 className="w-4 h-4" />
                   </button>
                   <button
+                    aria-label={`Delete event: ${event.title}`}
                     onClick={() => handleDelete(event.id)}
                     className="p-2 text-gray-400 dark:text-gray-500 hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-neutral-800 rounded transition-colors"
                   >

--- a/src/components/InboxView.tsx
+++ b/src/components/InboxView.tsx
@@ -399,6 +399,7 @@ export default function InboxView() {
                                     </div>
                                     
                                     <button 
+                                        aria-label={`Delete notification: ${notification.title}`}
                                         onClick={() => deleteNotification(notification.id)}
                                         className="text-gray-400 hover:text-red-500 opacity-0 group-hover:opacity-100 transition-opacity"
                                     >

--- a/src/components/WorkspaceView.tsx
+++ b/src/components/WorkspaceView.tsx
@@ -977,6 +977,7 @@ function TaskCard({ task, role, isManager, getMemberName, onUpdateStatus, onDele
                 <h4 className="text-sm font-medium text-gray-900 dark:text-gray-100 flex-1">{task.title}</h4>
                 {isManager && (
                     <button 
+                        aria-label={`Delete task: ${task.title}`}
                         onClick={() => onDelete(task.id)}
                         className="text-gray-400 hover:text-red-500 opacity-0 group-hover:opacity-100 transition-opacity"
                     >

--- a/src/components/ui/agent-plan.tsx
+++ b/src/components/ui/agent-plan.tsx
@@ -296,6 +296,7 @@ export default function Plan() {
 
                   {/* Delete Button */}
                   <button
+                    aria-label={`Delete project: ${project.title}`}
                     onClick={() => deleteItem(project.id)}
                     className="p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-md transition-colors"
                     title="Delete project"
@@ -414,6 +415,7 @@ export default function Plan() {
 
                               {/* Delete Button */}
                               <button
+                                aria-label={`Delete task: ${task.title}`}
                                 onClick={() => deleteItem(task.id)}
                                 className="p-1.5 text-gray-400 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-md transition-colors"
                                 title="Delete task"
@@ -511,6 +513,7 @@ export default function Plan() {
                                         {subtask.title}
                                       </span>
                                       <button
+                                        aria-label={`Delete subtask: ${subtask.title}`}
                                         onClick={() => deleteItem(subtask.id)}
                                         className="p-1 text-gray-400 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-md transition-colors"
                                         title="Delete subtask"


### PR DESCRIPTION
💡 What: Added explicit `aria-label`s containing the item's title to icon-only delete (`Trash2`) buttons in lists across the codebase.
🎯 Why: Without explicit context, screen reader users hear only "Delete" without knowing which specific task, project, event, or notification is being targeted, especially in complex nested lists or tables.
📸 Before/After: Visuals haven't changed.
♿ Accessibility: Ensures that screen reader users are provided with clear, unambiguous action context.

---
*PR created automatically by Jules for task [9952687924789605369](https://jules.google.com/task/9952687924789605369) started by @aryankumar06*