### PR TITLE
🎨 Palette: Add explicit context to expand/collapse icon-only buttons

### DIFF
--- a/src/components/ui/agent-plan.tsx
+++ b/src/components/ui/agent-plan.tsx
@@ -242,6 +242,7 @@ export default function Plan() {
                   {hasChildren && (
                     <button
                       onClick={() => toggleExpand(project.id)}
+                      aria-label={isExpanded ? `Collapse project: ${project.title}` : `Expand project: ${project.title}`}
                       className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
                     >
                       {isExpanded ? <ChevronDown className="w-5 h-5" /> : <ChevronRight className="w-5 h-5" />}
@@ -373,6 +374,7 @@ export default function Plan() {
                               {hasSubtasks && (
                                 <button
                                   onClick={() => toggleExpand(task.id)}
+                                  aria-label={isTaskExpanded ? `Collapse task: ${task.title}` : `Expand task: ${task.title}`}
                                   className="text-gray-400 hover:text-gray-600"
                                 >
                                   {isTaskExpanded ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}

--- a/src/components/ui/task-plan.tsx
+++ b/src/components/ui/task-plan.tsx
@@ -176,6 +176,7 @@ export default function TaskPlan({
                     {task.subtasks.length > 0 && (
                       <button
                         onClick={() => toggleTaskExpansion(task.id)}
+                        aria-label={isExpanded ? `Collapse task: ${task.title}` : `Expand task: ${task.title}`}
                         className="mr-1 p-0.5 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
                       >
                         {isExpanded ? (


### PR DESCRIPTION
💡 **What:** Added dynamic `aria-label`s with explicit item context to the icon-only expand/collapse buttons in both `task-plan.tsx` and `agent-plan.tsx`.

🎯 **Why:** Screen reader users navigating nested lists and trees need explicit context to understand what an icon-only button does. Without an `aria-label` stating what is being expanded or collapsed (e.g. `Collapse task: Build frontend`), the buttons were ambiguous and difficult to interact with confidently.

📸 **Before/After:** Not applicable (non-visual HTML accessibility attribute addition).

♿ **Accessibility:** Solves a WCAG 2.1 Success Criterion 4.1.2 Name, Role, Value issue by ensuring the action buttons are properly labeled with their contextual target.

---
*PR created automatically by Jules for task [7237263618748032923](https://jules.google.com/task/7237263618748032923) started by @aryankumar06*