### PR TITLE
🎨 Palette: Improve accessibility labels for action buttons

### DIFF
--- a/src/components/EventSection.tsx
+++ b/src/components/EventSection.tsx
@@ -223,6 +223,7 @@ export default function EventSection({ selectedDate }: EventSectionProps) {
                 </div>
                 <div className="flex items-center gap-1">
                   <button
+                    aria-label={`Edit event: ${event.title}`}
                     onClick={() => handleEdit(event)}
                     className="p-2 text-gray-400 dark:text-gray-500 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-blue-50 dark:hover:bg-neutral-800 rounded transition-colors"
                   >

--- a/src/components/TaskSection.tsx
+++ b/src/components/TaskSection.tsx
@@ -595,7 +595,7 @@ function TaskItem({
         <button
           onClick={() => onToggle(task)}
           className="mt-1 flex-shrink-0"
-          aria-label={task.status === 'completed' ? 'Mark as incomplete' : 'Mark as complete'}
+          aria-label={task.status === 'completed' ? `Mark as incomplete: ${task.title}` : `Mark as complete: ${task.title}`}
         >
           {task.status === 'completed' ? (
             <motion.div 
@@ -688,14 +688,14 @@ function TaskItem({
           <button
             onClick={() => onEdit(task)}
             className="p-2 text-gray-400 dark:text-gray-500 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-blue-50 dark:hover:bg-neutral-800 rounded transition-colors"
-            aria-label="Edit task"
+            aria-label={`Edit task: ${task.title}`}
           >
             <Edit2 className="w-4 h-4" />
           </button>
           <button
             onClick={() => onDelete(task.id)}
             className="p-2 text-gray-400 dark:text-gray-500 hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-neutral-800 rounded transition-colors"
-            aria-label="Delete task"
+            aria-label={`Delete task: ${task.title}`}
           >
             <Trash2 className="w-4 h-4" />
           </button>


### PR DESCRIPTION
**💡 What**: Added specific item titles to the `aria-label` attributes of icon-only action buttons (Edit, Delete, Toggle) in `TaskSection.tsx` and `EventSection.tsx`.

**🎯 Why**: Generic `aria-label`s like "Edit task" or "Delete event" provide no context for screen reader users when navigating through a list of items. By including the item's title (e.g., "Edit task: Buy Groceries"), users immediately understand which item the action applies to. This is a crucial accessibility best practice.

**📸 Before/After**: No visual changes, as this only modifies screen reader attributes (`aria-label`).

**♿ Accessibility**: Improved screen reader context for multiple action buttons across the `TaskSection` and `EventSection` components, ensuring adherence to standard a11y guidelines.

---
*PR created automatically by Jules for task [7371265751907174731](https://jules.google.com/task/7371265751907174731) started by @aryankumar06*