### PR TITLE
🎨 Palette: Add explicit context to task action button aria-labels

### DIFF
--- a/src/components/TaskSection.tsx
+++ b/src/components/TaskSection.tsx
@@ -595,7 +595,7 @@ function TaskItem({
         <button
           onClick={() => onToggle(task)}
           className="mt-1 flex-shrink-0"
-          aria-label={task.status === 'completed' ? 'Mark as incomplete' : 'Mark as complete'}
+          aria-label={task.status === 'completed' ? `Mark task incomplete: ${task.title}` : `Mark task complete: ${task.title}`}
         >
           {task.status === 'completed' ? (
             <motion.div 
@@ -688,14 +688,14 @@ function TaskItem({
           <button
             onClick={() => onEdit(task)}
             className="p-2 text-gray-400 dark:text-gray-500 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-blue-50 dark:hover:bg-neutral-800 rounded transition-colors"
-            aria-label="Edit task"
+            aria-label={`Edit task: ${task.title}`}
           >
             <Edit2 className="w-4 h-4" />
           </button>
           <button
             onClick={() => onDelete(task.id)}
             className="p-2 text-gray-400 dark:text-gray-500 hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-neutral-800 rounded transition-colors"
-            aria-label="Delete task"
+            aria-label={`Delete task: ${task.title}`}
           >
             <Trash2 className="w-4 h-4" />
           </button>


### PR DESCRIPTION
### 💡 What
Updated the `aria-label`s on icon-only action buttons (Edit, Delete, and Toggle Complete) within the task list to include the dynamic task title (e.g., `aria-label="Delete task: Design New Logo"`).

### 🎯 Why
When navigating a list of tasks, identical static labels like "Delete task" or "Edit task" across multiple rows provide no context to screen reader users about *which* task they are modifying. Including the task title clarifies the target of the action.

### 📸 Before/After
Since this is an accessibility change affecting only HTML attributes, there is no visual change. 
*   **Before:** `<button aria-label="Edit task">`
*   **After:** `<button aria-label="Edit task: Update README">`

### ♿ Accessibility
This directly improves screen reader accessibility by providing unique, descriptive context for icon-only action buttons within a list, resolving ambiguity for users relying on assistive technologies.

---
*PR created automatically by Jules for task [7117816666723033938](https://jules.google.com/task/7117816666723033938) started by @aryankumar06*