### PR TITLE
🎨 Palette: Add explicit context to aria-labels for list action buttons

### DIFF
--- a/src/components/TaskSection.tsx
+++ b/src/components/TaskSection.tsx
@@ -688,14 +688,14 @@ function TaskItem({
           <button
             onClick={() => onEdit(task)}
             className="p-2 text-gray-400 dark:text-gray-500 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-blue-50 dark:hover:bg-neutral-800 rounded transition-colors"
-            aria-label="Edit task"
+            aria-label={`Edit task: ${task.title}`}
           >
             <Edit2 className="w-4 h-4" />
           </button>
           <button
             onClick={() => onDelete(task.id)}
             className="p-2 text-gray-400 dark:text-gray-500 hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-neutral-800 rounded transition-colors"
-            aria-label="Delete task"
+            aria-label={`Delete task: ${task.title}`}
           >
             <Trash2 className="w-4 h-4" />
           </button>

--- a/src/components/WorkspaceView.tsx
+++ b/src/components/WorkspaceView.tsx
@@ -645,7 +645,7 @@ export default function WorkspaceView() {
                                         </span>
                                         {canManageMembers && m.user_id !== user?.id && (
                                             <button 
-                                                aria-label="Remove member"
+                                                aria-label={`Remove member: ${m.display_name || m.email?.split('@')[0] || 'User'}`}
                                                 onClick={() => handleRemoveMember(m.id, m.user_id)}
                                                 className="ml-1 text-gray-400 hover:text-red-500"
                                             >


### PR DESCRIPTION
**💡 What:** 
Added explicit item context (e.g., Task Title, Member Name) to `aria-label` attributes on icon-only action buttons within repeatable lists.

**🎯 Why:** 
Screen reader users navigating through lists element-by-element, or using a "list of buttons" feature, previously heard identical, unhelpful announcements like "Edit task" or "Remove member" repeatedly without knowing *which* task or member the button affected. By appending the specific item's name to the label, it provides immediate and necessary context.

**📸 Before/After:** 
*   **Before:** `<button aria-label="Edit task">...</button>`
*   **After:** `<button aria-label="Edit task: Complete project documentation">...</button>`

**♿ Accessibility:** 
Significantly improves WCAG 2.1 Success Criterion 4.1.2 (Name, Role, Value) by ensuring interactive elements have descriptive, unique names that provide clear context of their purpose.

---
*PR created automatically by Jules for task [6080323794012249991](https://jules.google.com/task/6080323794012249991) started by @aryankumar06*