### PR TITLE
🎨 Palette: Add explicit context to action button aria-labels

### DIFF
--- a/src/components/EventSection.tsx
+++ b/src/components/EventSection.tsx
@@ -223,6 +223,7 @@ export default function EventSection({ selectedDate }: EventSectionProps) {
                 </div>
                 <div className="flex items-center gap-1">
                   <button
+                    aria-label={`Edit event: ${event.title}`}
                     onClick={() => handleEdit(event)}
                     className="p-2 text-gray-400 dark:text-gray-500 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-blue-50 dark:hover:bg-neutral-800 rounded transition-colors"
                   >

--- a/src/components/TaskSection.tsx
+++ b/src/components/TaskSection.tsx
@@ -595,7 +595,7 @@ function TaskItem({
         <button
           onClick={() => onToggle(task)}
           className="mt-1 flex-shrink-0"
-          aria-label={task.status === 'completed' ? 'Mark as incomplete' : 'Mark as complete'}
+          aria-label={task.status === 'completed' ? `Mark task incomplete: ${task.title}` : `Mark task complete: ${task.title}`}
         >
           {task.status === 'completed' ? (
             <motion.div 
@@ -688,14 +688,14 @@ function TaskItem({
           <button
             onClick={() => onEdit(task)}
             className="p-2 text-gray-400 dark:text-gray-500 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-blue-50 dark:hover:bg-neutral-800 rounded transition-colors"
-            aria-label="Edit task"
+            aria-label={`Edit task: ${task.title}`}
           >
             <Edit2 className="w-4 h-4" />
           </button>
           <button
             onClick={() => onDelete(task.id)}
             className="p-2 text-gray-400 dark:text-gray-500 hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-neutral-800 rounded transition-colors"
-            aria-label="Delete task"
+            aria-label={`Delete task: ${task.title}`}
           >
             <Trash2 className="w-4 h-4" />
           </button>


### PR DESCRIPTION
**💡 What:** 
Added context-aware `aria-label`s to icon-only action buttons in the Task and Event lists. Specifically, the task title or event title is now included in the ARIA label (e.g., instead of "Edit task", it now says "Edit task: Finish report").

**🎯 Why:**
For users relying on screen readers, generic labels like "Edit" or "Delete" on list items are confusing when tabbing through the interface, as the context is lost. Including the item's title in the label provides immediate clarity on which item the action applies to.

**📸 Before/After:**
*N/A - purely non-visual DOM change.*

**♿ Accessibility:**
- Task completion toggle: "Mark task complete/incomplete: [Title]"
- Task Edit button: "Edit task: [Title]"
- Task Delete button: "Delete task: [Title]"
- Event Edit button: "Edit event: [Title]"

---
*PR created automatically by Jules for task [8864647987150673154](https://jules.google.com/task/8864647987150673154) started by @aryankumar06*