### PR TITLE
🎨 Palette: Add ARIA label to modal close button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,6 @@
 ## 2026-06-08 - Explicit Context for Icon-Only Action Buttons in Lists
 **Learning:** Icon-only action buttons (like Delete) in nested lists or trees without the item's context in the aria-label are ambiguous to screen reader users.
 **Action:** When adding icon-only action buttons to items in lists, always include the specific item's title in the `aria-label` (e.g., `aria-label="Delete task: [Task Title]"`) to provide explicit context.
+## 2024-05-19 - Icon-only Buttons in Modals
+**Learning:** Found an icon-only `<button>` containing a `<X />` icon (used for closing a modal) in `WorkspaceView.tsx` that lacked an `aria-label`. This pattern of missing ARIA labels on close buttons is a common accessibility oversight that prevents screen readers from understanding the button's purpose.
+**Action:** Always verify that every `<button>` lacking textual content, especially those used for common actions like closing modals (e.g., those containing an `<X />` or `CloseIcon`), explicitly includes a descriptive `aria-label` (e.g., `aria-label="Close modal"`).

--- a/src/components/WorkspaceView.tsx
+++ b/src/components/WorkspaceView.tsx
@@ -938,7 +938,7 @@ function Modal({ onClose, title, children }: ModalProps) {
             <div className="bg-white dark:bg-neutral-900 w-full max-w-md rounded-2xl shadow-xl border border-gray-200 dark:border-neutral-800">
                 <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-neutral-800">
                     <h3 className="text-lg font-bold dark:text-white">{title}</h3>
-                    <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+                    <button aria-label="Close modal" onClick={onClose} className="text-gray-400 hover:text-gray-600">
                         <X className="w-5 h-5" />
                     </button>
                 </div>


### PR DESCRIPTION
### 💡 What
Added an `aria-label="Close modal"` to the icon-only close button within the `Modal` component in `src/components/WorkspaceView.tsx`.

### 🎯 Why
Screen readers need textual context to announce the purpose of buttons that only contain icons (like the `<X />` icon). Without an `aria-label`, screen reader users might not know what this button does.

### 📸 Before/After
*N/A - This is a non-visual accessibility improvement.*

### ♿ Accessibility
- Provides explicit, readable text for the modal close button, improving navigation and understanding for users relying on assistive technologies.

---
*PR created automatically by Jules for task [16981302571255435182](https://jules.google.com/task/16981302571255435182) started by @aryankumar06*