### PR TITLE
🎨 Palette: Improve accessibility of icon-only action buttons

### DIFF
--- a/src/components/EisenhowerMatrix.tsx
+++ b/src/components/EisenhowerMatrix.tsx
@@ -228,6 +228,7 @@ function DroppableQuadrant({ id, title, tasks, addingToQuadrant, setAddingToQuad
           <div className="flex items-center gap-2">
               <span className="bg-white/50 dark:bg-black/20 px-2 py-0.5 rounded text-sm">{tasks.length}</span>
               <button 
+                  aria-label={`Add task to ${title}`}
                   onClick={() => { setAddingToQuadrant(id); setTimeout(() => document.getElementById(`input-${id}`)?.focus(), 50); }}
                   className="p-1 hover:bg-black/10 dark:hover:bg-white/10 rounded transition-colors"
               >

--- a/src/components/HabitSection.tsx
+++ b/src/components/HabitSection.tsx
@@ -356,7 +356,9 @@ export default function HabitSection({ selectedDate }: HabitSectionProps) {
                 ))}
                 {visibleHabits.length === 0 && <th className="px-6 py-3 text-sm text-gray-600 italic border-r border-[#2a2a2a]">{searchQuery ? 'No matches' : 'No habits yet'}</th>}
                 <th className="text-center px-4 py-3 text-sm font-medium text-gray-400 border-r border-[#2a2a2a] w-16">
-                  <Plus className="w-4 h-4 mx-auto cursor-pointer hover:text-white" onClick={() => setShowForm(true)} />
+                  <button aria-label="Add habit" onClick={() => setShowForm(true)} className="mx-auto block text-gray-400 hover:text-white">
+                    <Plus className="w-4 h-4" />
+                  </button>
                 </th>
                 <th className="text-center px-4 py-3 text-sm font-medium text-gray-400 w-16">
                   <MoreHorizontal className="w-4 h-4 mx-auto" />

--- a/src/components/WorkspaceView.tsx
+++ b/src/components/WorkspaceView.tsx
@@ -938,7 +938,7 @@ function Modal({ onClose, title, children }: ModalProps) {
             <div className="bg-white dark:bg-neutral-900 w-full max-w-md rounded-2xl shadow-xl border border-gray-200 dark:border-neutral-800">
                 <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-neutral-800">
                     <h3 className="text-lg font-bold dark:text-white">{title}</h3>
-                    <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+                    <button aria-label={`Close ${title} modal`} onClick={onClose} className="text-gray-400 hover:text-gray-600">
                         <X className="w-5 h-5" />
                     </button>
                 </div>


### PR DESCRIPTION
**💡 What:**
Added `aria-label` attributes to icon-only action buttons in several components.

**🎯 Why:**
Icon-only buttons rely entirely on visuals to communicate their purpose. Screen readers cannot interpret them, making the application harder to use for visually impaired users. Additionally, raw SVG elements acting as clickable targets lack standard keyboard focus behavior.

**📸 Before/After:**
*(No visual changes - purely structural accessibility enhancement)*

**♿ Accessibility:**
- `EisenhowerMatrix`: Added context-specific labels when adding tasks to different quadrants.
- `HabitSection`: Converted a raw `<Plus>` SVG into a proper `<button>` element with `aria-label`, enabling proper tab navigation and screen reader announcement.
- `WorkspaceView`: Added missing `aria-label` on the global modal close button.

---
*PR created automatically by Jules for task [8832589284562069623](https://jules.google.com/task/8832589284562069623) started by @aryankumar06*