### PR TITLE
🎨 Palette: Add explicit context to task action aria-labels

### DIFF
--- a/src/components/TaskSection.tsx
+++ b/src/components/TaskSection.tsx
@@ -595,7 +595,7 @@ function TaskItem({
         <button
           onClick={() => onToggle(task)}
           className="mt-1 flex-shrink-0"
-          aria-label={task.status === 'completed' ? 'Mark as incomplete' : 'Mark as complete'}
+          aria-label={task.status === 'completed' ? `Mark task incomplete: ${task.title}` : `Mark task complete: ${task.title}`}
         >
           {task.status === 'completed' ? (
             <motion.div 
@@ -688,14 +688,14 @@ function TaskItem({
           <button
             onClick={() => onEdit(task)}
             className="p-2 text-gray-400 dark:text-gray-500 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-blue-50 dark:hover:bg-neutral-800 rounded transition-colors"
-            aria-label="Edit task"
+            aria-label={`Edit task: ${task.title}`}
           >
             <Edit2 className="w-4 h-4" />
           </button>
           <button
             onClick={() => onDelete(task.id)}
             className="p-2 text-gray-400 dark:text-gray-500 hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-neutral-800 rounded transition-colors"
-            aria-label="Delete task"
+            aria-label={`Delete task: ${task.title}`}
           >
             <Trash2 className="w-4 h-4" />
           </button>


### PR DESCRIPTION
* 💡 What: Added task titles to the `aria-label`s for the toggle complete, edit, and delete icon-only buttons in the Task list view.
* 🎯 Why: Icon-only action buttons without explicit context in their aria-label can be confusing for screen reader users as they lack spatial context, resulting in them hearing multiple non-distinctive "Edit task" or "Delete task" items.
* 📸 Before/After: Visuals are unchanged.
* ♿ Accessibility: Screen readers will now announce "Delete task: [Task Title]" instead of generically "Delete task".

---
*PR created automatically by Jules for task [3710061975744957244](https://jules.google.com/task/3710061975744957244) started by @aryankumar06*