### PR TITLE
🎨 Palette: Explicit aria-labels for task action buttons

### DIFF
--- a/src/components/TaskSection.tsx
+++ b/src/components/TaskSection.tsx
@@ -595,7 +595,7 @@ function TaskItem({
         <button
           onClick={() => onToggle(task)}
           className="mt-1 flex-shrink-0"
-          aria-label={task.status === 'completed' ? 'Mark as incomplete' : 'Mark as complete'}
+          aria-label={task.status === 'completed' ? `Mark as incomplete: ${task.title}` : `Mark as complete: ${task.title}`}
         >
           {task.status === 'completed' ? (
             <motion.div 
@@ -688,14 +688,14 @@ function TaskItem({
           <button
             onClick={() => onEdit(task)}
             className="p-2 text-gray-400 dark:text-gray-500 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-blue-50 dark:hover:bg-neutral-800 rounded transition-colors"
-            aria-label="Edit task"
+            aria-label={`Edit task: ${task.title}`}
           >
             <Edit2 className="w-4 h-4" />
           </button>
           <button
             onClick={() => onDelete(task.id)}
             className="p-2 text-gray-400 dark:text-gray-500 hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-neutral-800 rounded transition-colors"
-            aria-label="Delete task"
+            aria-label={`Delete task: ${task.title}`}
           >
             <Trash2 className="w-4 h-4" />
           </button>


### PR DESCRIPTION
**💡 What:** Added explicit task context (titles) to the `aria-label` attributes for icon-only action buttons (Complete/Incomplete toggle, Edit, Delete) in `src/components/TaskSection.tsx`.

**🎯 Why:** Action buttons in nested lists or groups without item-specific context are ambiguous to screen reader users (e.g., hearing "Edit task" ten times without knowing which task it applies to). Adding the specific item's title ensures users relying on assistive technology have the context they need.

**📸 Before/After:** N/A (Visual change is none. This is purely an HTML accessibility enhancement for screen readers.)

**♿ Accessibility:** Improves screen reader experience by making action buttons explicit (e.g., from `aria-label="Edit task"` to `aria-label="Edit task: Buy Groceries"`). This adheres to the standard documented in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [17939419223031523188](https://jules.google.com/task/17939419223031523188) started by @aryankumar06*