### PR TITLE
🎨 Palette: Add aria-label to Modal close button

### DIFF
--- a/src/components/WorkspaceView.tsx
+++ b/src/components/WorkspaceView.tsx
@@ -938,7 +938,7 @@ function Modal({ onClose, title, children }: ModalProps) {
             <div className="bg-white dark:bg-neutral-900 w-full max-w-md rounded-2xl shadow-xl border border-gray-200 dark:border-neutral-800">
                 <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-neutral-800">
                     <h3 className="text-lg font-bold dark:text-white">{title}</h3>
-                    <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+                    <button aria-label="Close modal" onClick={onClose} className="text-gray-400 hover:text-gray-600">
                         <X className="w-5 h-5" />
                     </button>
                 </div>


### PR DESCRIPTION
## 💡 What:
Added an `aria-label="Close modal"` to the icon-only `<button>` inside the `<Modal>` component in `src/components/WorkspaceView.tsx`.

## 🎯 Why:
The Modal component in `WorkspaceView.tsx` had an icon-only button (an `X` icon from lucide-react) for closing the modal without any text alternative. This is a common accessibility issue because screen readers will not announce the button's purpose to visually impaired users, leaving them to guess what the button does.

## 📸 Before/After:
**Before:**
```tsx
<button onClick={onClose} className="text-gray-400 hover:text-gray-600">
    <X className="w-5 h-5" />
</button>
```

**After:**
```tsx
<button aria-label="Close modal" onClick={onClose} className="text-gray-400 hover:text-gray-600">
    <X className="w-5 h-5" />
</button>
```

## ♿ Accessibility:
- The close button in modals is now perceivable by screen readers, which will correctly announce "Close modal button" instead of just "button". This directly adheres to WCAG guidelines for non-text content and makes the UI more inclusive.

---
*PR created automatically by Jules for task [5568067424101962200](https://jules.google.com/task/5568067424101962200) started by @aryankumar06*