### PR TITLE
🎨 Palette: Improve accessibility of task action buttons

### DIFF
--- a/src/components/TaskSection.tsx
+++ b/src/components/TaskSection.tsx
@@ -595,7 +595,7 @@ function TaskItem({
         <button
           onClick={() => onToggle(task)}
           className="mt-1 flex-shrink-0"
-          aria-label={task.status === 'completed' ? 'Mark as incomplete' : 'Mark as complete'}
+          aria-label={task.status === 'completed' ? `Mark incomplete: ${task.title}` : `Mark complete: ${task.title}`}
         >
           {task.status === 'completed' ? (
             <motion.div 
@@ -688,14 +688,14 @@ function TaskItem({
           <button
             onClick={() => onEdit(task)}
             className="p-2 text-gray-400 dark:text-gray-500 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-blue-50 dark:hover:bg-neutral-800 rounded transition-colors"
-            aria-label="Edit task"
+            aria-label={`Edit task: ${task.title}`}
           >
             <Edit2 className="w-4 h-4" />
           </button>
           <button
             onClick={() => onDelete(task.id)}
             className="p-2 text-gray-400 dark:text-gray-500 hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-neutral-800 rounded transition-colors"
-            aria-label="Delete task"
+            aria-label={`Delete task: ${task.title}`}
           >
             <Trash2 className="w-4 h-4" />
           </button>


### PR DESCRIPTION
### 💡 What
Added explicit context to the `aria-label`s of the toggle, edit, and delete action buttons for individual tasks in `TaskSection.tsx` by interpolating the task's title.

### 🎯 Why
Icon-only buttons within lists that use generic labels (e.g., "Edit task", "Delete task") are confusing for screen reader users because they lack context about *which* specific item the action applies to. This change ensures screen readers announce the action alongside the item it affects (e.g., "Edit task: Buy groceries").

### 📸 Before/After
*(Visuals remain unchanged as this is an accessibility improvement applied to ARIA attributes)*

### ♿ Accessibility
- Replaced generic `aria-label`s on task action buttons with explicit ones.
- Toggle button: `aria-label="Mark complete/incomplete"` -> `aria-label="Mark complete/incomplete: [Task Title]"`
- Edit button: `aria-label="Edit task"` -> `aria-label="Edit task: [Task Title]"`
- Delete button: `aria-label="Delete task"` -> `aria-label="Delete task: [Task Title]"`

---
*PR created automatically by Jules for task [14669818175650641567](https://jules.google.com/task/14669818175650641567) started by @aryankumar06*