### PR TITLE
🎨 Palette: Add aria-label to Modal close button

### DIFF
--- a/src/components/WorkspaceView.tsx
+++ b/src/components/WorkspaceView.tsx
@@ -938,7 +938,7 @@ function Modal({ onClose, title, children }: ModalProps) {
             <div className="bg-white dark:bg-neutral-900 w-full max-w-md rounded-2xl shadow-xl border border-gray-200 dark:border-neutral-800">
                 <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-neutral-800">
                     <h3 className="text-lg font-bold dark:text-white">{title}</h3>
-                    <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+                    <button aria-label="Close modal" onClick={onClose} className="text-gray-400 hover:text-gray-600">
                         <X className="w-5 h-5" />
                     </button>
                 </div>


### PR DESCRIPTION
### 💡 What
Added an `aria-label="Close modal"` to the icon-only "Close" button inside the reusable `Modal` component in `src/components/WorkspaceView.tsx`.

### 🎯 Why
Icon-only buttons must have an accessible name so that screen readers can interpret them correctly. Without an `aria-label`, users relying on assistive technologies wouldn't know the purpose of the `<X />` button when focusing it. This fix makes the interface more accessible for everyone.

### 📸 Before/After
**Before:** `<button onClick={onClose} className="text-gray-400 hover:text-gray-600"><X className="w-5 h-5" /></button>` (No accessible name)
**After:** `<button aria-label="Close modal" onClick={onClose} className="text-gray-400 hover:text-gray-600"><X className="w-5 h-5" /></button>` (Properly labelled)

### ♿ Accessibility
Improved a11y by giving an explicit role description to the closing action of the Modal window, ensuring smooth keyboard navigation and screen-reader announcements.

---
*PR created automatically by Jules for task [17682880584321627521](https://jules.google.com/task/17682880584321627521) started by @aryankumar06*