### PR TITLE
🎨 Palette: Explicit aria-labels for expand buttons

### DIFF
--- a/src/components/ui/agent-plan.tsx
+++ b/src/components/ui/agent-plan.tsx
@@ -241,6 +241,7 @@ export default function Plan() {
                   {/* Expand/Collapse */}
                   {hasChildren && (
                     <button
+                      aria-label={`${isExpanded ? 'Collapse' : 'Expand'} project: ${project.title}`}
                       onClick={() => toggleExpand(project.id)}
                       className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
                     >
@@ -372,6 +373,7 @@ export default function Plan() {
                               {/* Expand/Collapse */}
                               {hasSubtasks && (
                                 <button
+                                  aria-label={`${isTaskExpanded ? 'Collapse' : 'Expand'} task: ${task.title}`}
                                   onClick={() => toggleExpand(task.id)}
                                   className="text-gray-400 hover:text-gray-600"
                                 >


### PR DESCRIPTION
### 💡 What:
Added explicit, context-aware `aria-label`s to the expand/collapse icon-only buttons for both projects and tasks in the `agent-plan.tsx` component.

### 🎯 Why:
To improve accessibility for screen reader users. Previously, the buttons were icon-only (Chevrons), and assistive technologies lacked context on what the button would expand or collapse. Now, the label explicitly announces action and context, e.g., "Expand project: Website Redesign" or "Collapse task: Design Mocks".

### 📸 Before/After:
**Before:** Screen readers would only announce "button", giving no clue as to what the button interacts with.
**After:** Screen readers announce, for example, "Collapse project: [Project Title]" or "Expand task: [Task Title]", giving full context.

### ♿ Accessibility:
- Added `aria-label={`${isExpanded ? 'Collapse' : 'Expand'} project: ${project.title}`}` to project toggle buttons.
- Added `aria-label={`${isTaskExpanded ? 'Collapse' : 'Expand'} task: ${task.title}`}` to task toggle buttons.

---
*PR created automatically by Jules for task [4938266229463079292](https://jules.google.com/task/4938266229463079292) started by @aryankumar06*