### PR TITLE
🎨 Palette: Add ARIA label to Sign Out button

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -167,6 +167,7 @@ export default function Dashboard() {
                 onClick={signOut}
                 className="flex items-center gap-2 px-4 py-2 text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-neutral-800 rounded-lg transition-colors"
                 title="Sign Out"
+                aria-label="Sign Out"
               >
                 <LogOut className="w-4 h-4" />
               </button>


### PR DESCRIPTION
### 💡 What
Added an explicit `aria-label="Sign Out"` to the icon-only sign-out button in the top navigation bar (`src/components/Dashboard.tsx`).

### 🎯 Why
While the button previously had a `title` attribute which provides a tooltip for mouse users, relying solely on the `title` attribute for screen reader accessibility is not universally supported or reliable. Adding an explicit `aria-label` ensures that visually impaired users navigating with a screen reader will hear "Sign Out" instead of just "button" or the SVG's filename. 

### 📸 Before/After
**Before:**
```tsx
<button
  onClick={signOut}
  className="..."
  title="Sign Out"
>
  <LogOut className="w-4 h-4" />
</button>
```

**After:**
```tsx
<button
  onClick={signOut}
  className="..."
  title="Sign Out"
  aria-label="Sign Out"
>
  <LogOut className="w-4 h-4" />
</button>
```

### ♿ Accessibility
- Improves screen reader support for the sign-out action by explicitly declaring its accessible name.

---
*PR created automatically by Jules for task [12275776400194000498](https://jules.google.com/task/12275776400194000498) started by @aryankumar06*