### PR TITLE
🎨 Palette: Add ARIA labels to expand/collapse buttons in nested tree

### DIFF
--- a/src/components/ui/agent-plan.tsx
+++ b/src/components/ui/agent-plan.tsx
@@ -243,6 +243,7 @@ export default function Plan() {
                     <button
                       onClick={() => toggleExpand(project.id)}
                       className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+                      aria-label={isExpanded ? `Collapse project: ${project.title}` : `Expand project: ${project.title}`}
                     >
                       {isExpanded ? <ChevronDown className="w-5 h-5" /> : <ChevronRight className="w-5 h-5" />}
                     </button>
@@ -374,6 +375,7 @@ export default function Plan() {
                                 <button
                                   onClick={() => toggleExpand(task.id)}
                                   className="text-gray-400 hover:text-gray-600"
+                                  aria-label={isTaskExpanded ? `Collapse task: ${task.title}` : `Expand task: ${task.title}`}
                                 >
                                   {isTaskExpanded ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
                                 </button>


### PR DESCRIPTION
💡 What: Added context-aware ARIA labels to the icon-only expand/collapse buttons in the nested project/task tree (`agent-plan.tsx`).
🎯 Why: Screen reader users wouldn't know which item was being expanded or collapsed when navigating to the Chevron buttons.
📸 Before/After: N/A (non-visual accessibility change)
♿ Accessibility: Added `aria-label="Expand/Collapse project: [title]"` and `aria-label="Expand/Collapse task: [title]"` to the respective ChevronDown/ChevronRight buttons.

---
*PR created automatically by Jules for task [7419306923578803747](https://jules.google.com/task/7419306923578803747) started by @aryankumar06*