### PR TITLE
🎨 Palette: Add missing ARIA labels to icon-only buttons

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -167,6 +167,7 @@ export default function Dashboard() {
                 onClick={signOut}
                 className="flex items-center gap-2 px-4 py-2 text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-neutral-800 rounded-lg transition-colors"
                 title="Sign Out"
+                aria-label="Sign out"
               >
                 <LogOut className="w-4 h-4" />
               </button>

--- a/src/components/EisenhowerMatrix.tsx
+++ b/src/components/EisenhowerMatrix.tsx
@@ -230,6 +230,7 @@ function DroppableQuadrant({ id, title, tasks, addingToQuadrant, setAddingToQuad
               <button 
                   onClick={() => { setAddingToQuadrant(id); setTimeout(() => document.getElementById(`input-${id}`)?.focus(), 50); }}
                   className="p-1 hover:bg-black/10 dark:hover:bg-white/10 rounded transition-colors"
+                  aria-label={`Add task to ${title}`}
               >
                   <Plus className="w-4 h-4" />
               </button>

--- a/src/components/EventSection.tsx
+++ b/src/components/EventSection.tsx
@@ -225,6 +225,7 @@ export default function EventSection({ selectedDate }: EventSectionProps) {
                   <button
                     onClick={() => handleEdit(event)}
                     className="p-2 text-gray-400 dark:text-gray-500 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-blue-50 dark:hover:bg-neutral-800 rounded transition-colors"
+                    aria-label={`Edit event: ${event.title}`}
                   >
                     <Edit2 className="w-4 h-4" />
                   </button>


### PR DESCRIPTION
**💡 What:** 
Added `aria-label` attributes to multiple icon-only action buttons across the application (Dashboard Sign Out, Eisenhower Matrix Add Task, and Event Section Edit Event).

**🎯 Why:** 
Icon-only buttons without accessible labels are completely invisible or announced ambiguously to screen reader users (e.g., they just read as "button"). Adding context-specific labels improves accessibility by clearly stating the button's action.

**📸 Before/After:** 
_Before_: Buttons relying solely on icons and `title` attributes, lacking screen-reader accessible names.
_After_: Buttons have clear, context-aware `aria-label` attributes.

**♿ Accessibility:** 
Improves WCAG 2.1 compliance (Success Criterion 4.1.2 Name, Role, Value) by giving programmatic labels to interactive icon elements, greatly enhancing the experience for assistive technology users.

---
*PR created automatically by Jules for task [17571180068162120842](https://jules.google.com/task/17571180068162120842) started by @aryankumar06*