### PR TITLE
🎨 Palette: Add aria-labels to icon-only buttons

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -167,6 +167,7 @@ export default function Dashboard() {
                 onClick={signOut}
                 className="flex items-center gap-2 px-4 py-2 text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-neutral-800 rounded-lg transition-colors"
                 title="Sign Out"
+                aria-label="Sign Out"
               >
                 <LogOut className="w-4 h-4" />
               </button>

--- a/src/components/WorkspaceView.tsx
+++ b/src/components/WorkspaceView.tsx
@@ -938,7 +938,7 @@ function Modal({ onClose, title, children }: ModalProps) {
             <div className="bg-white dark:bg-neutral-900 w-full max-w-md rounded-2xl shadow-xl border border-gray-200 dark:border-neutral-800">
                 <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-neutral-800">
                     <h3 className="text-lg font-bold dark:text-white">{title}</h3>
-                    <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+                    <button onClick={onClose} aria-label="Close modal" className="text-gray-400 hover:text-gray-600">
                         <X className="w-5 h-5" />
                     </button>
                 </div>


### PR DESCRIPTION
💡 **What**: Added `aria-label` attributes to icon-only buttons in `Dashboard.tsx` (Sign Out) and `WorkspaceView.tsx` (Close Modal).
🎯 **Why**: To improve accessibility for screen reader users by providing explicit context for actions represented only by icons.
📸 **Before/After**: Visually unchanged.
♿ **Accessibility**: Enhanced screen reader support by replacing ambiguous visual elements with explicit descriptive text.

---
*PR created automatically by Jules for task [4713149123196342295](https://jules.google.com/task/4713149123196342295) started by @aryankumar06*