### PR TITLE
🎨 Palette: Add specific ARIA labels to nested list icon buttons

### DIFF
--- a/src/components/ui/agent-plan.tsx
+++ b/src/components/ui/agent-plan.tsx
@@ -241,6 +241,7 @@ export default function Plan() {
                   {/* Expand/Collapse */}
                   {hasChildren && (
                     <button
+                      aria-label={`${isExpanded ? 'Collapse' : 'Expand'} project: ${project.title}`}
                       onClick={() => toggleExpand(project.id)}
                       className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
                     >
@@ -250,6 +251,7 @@ export default function Plan() {
 
                   {/* Status Icon - Animated */}
                   <motion.button
+                    aria-label={`Toggle status for project: ${project.title}`}
                     onClick={() => toggleStatus(project.id, project.status)}
                     className="flex-shrink-0 hover:opacity-80 transition-opacity"
                   >
@@ -372,6 +374,7 @@ export default function Plan() {
                               {/* Expand/Collapse */}
                               {hasSubtasks && (
                                 <button
+                                  aria-label={`${isTaskExpanded ? 'Collapse' : 'Expand'} task: ${task.title}`}
                                   onClick={() => toggleExpand(task.id)}
                                   className="text-gray-400 hover:text-gray-600"
                                 >
@@ -381,6 +384,7 @@ export default function Plan() {
 
                               {/* Status Icon - Animated */}
                               <motion.button
+                                aria-label={`Toggle status for task: ${task.title}`}
                                 onClick={() => toggleStatus(task.id, task.status)}
                                 className="flex-shrink-0 hover:opacity-80 transition-opacity"
                               >
@@ -484,6 +488,7 @@ export default function Plan() {
                                   {task.subtasks.map((subtask) => (
                                     <div key={subtask.id} className="flex items-center gap-3 py-1">
                                       <motion.button
+                                        aria-label={`Toggle status for subtask: ${subtask.title}`}
                                         onClick={() => toggleStatus(subtask.id, subtask.status)}
                                         className="flex-shrink-0 hover:opacity-80 transition-opacity"
                                       >


### PR DESCRIPTION
**💡 What:** Added explicit `aria-label`s to the Expand/Collapse and Status Toggle icon-only buttons in the Agent Plan component hierarchy (Projects, Tasks, Subtasks).

**🎯 Why:** Screen readers need explicit context for icon-only buttons. Using dynamic labels like "Expand project: [Title]" or "Toggle status for task: [Title]" helps visually impaired users understand exactly what action they are taking and on which specific item in the nested list, rather than just hearing "button".

**📸 Before/After:** (No visual changes)

**♿ Accessibility:**
- Added specific `aria-label` to Project expand/collapse chevron
- Added specific `aria-label` to Project status circle
- Added specific `aria-label` to Task expand/collapse chevron
- Added specific `aria-label` to Task status circle
- Added specific `aria-label` to Subtask status circle

---
*PR created automatically by Jules for task [249035120133007487](https://jules.google.com/task/249035120133007487) started by @aryankumar06*