### PR TITLE
🎨 Palette: Add context to Edit event button

### DIFF
--- a/src/components/EventSection.tsx
+++ b/src/components/EventSection.tsx
@@ -225,6 +225,7 @@ export default function EventSection({ selectedDate }: EventSectionProps) {
                   <button
                     onClick={() => handleEdit(event)}
                     className="p-2 text-gray-400 dark:text-gray-500 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-blue-50 dark:hover:bg-neutral-800 rounded transition-colors"
+                    aria-label={`Edit event: ${event.title}`}
                   >
                     <Edit2 className="w-4 h-4" />
                   </button>


### PR DESCRIPTION
💡 **What:** Added an `aria-label` to the icon-only "Edit event" button in `EventSection.tsx` (e.g., `aria-label="Edit event: Standup"`).
🎯 **Why:** To ensure screen reader users have explicit context for what event they are editing, reducing ambiguity in lists.
📸 **Before/After:** No visual changes.
♿ **Accessibility:** Provides explicit context for the Edit action in a list of events.

---
*PR created automatically by Jules for task [2346086830315749031](https://jules.google.com/task/2346086830315749031) started by @aryankumar06*