### PR TITLE
🎨 Palette: Add context to expand/collapse buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-06-08 - Explicit Context for Icon-Only Action Buttons in Lists
 **Learning:** Icon-only action buttons (like Delete) in nested lists or trees without the item's context in the aria-label are ambiguous to screen reader users.
 **Action:** When adding icon-only action buttons to items in lists, always include the specific item's title in the `aria-label` (e.g., `aria-label="Delete task: [Task Title]"`) to provide explicit context.
+
+## 2024-07-09 - Accessible tree navigation buttons
+**Learning:** When adding icon-only action buttons (like Expand/Collapse) to items in nested lists or trees, it is necessary to include the specific item's title in the `aria-label` (e.g., `aria-label="Expand project: [Title]"`) to provide explicit context for screen readers.
+**Action:** Always include the specific item's title in the `aria-label` of icon-only action buttons in nested lists or trees.

--- a/src/components/ui/agent-plan.tsx
+++ b/src/components/ui/agent-plan.tsx
@@ -241,6 +241,7 @@ export default function Plan() {
                   {/* Expand/Collapse */}
                   {hasChildren && (
                     <button
+                      aria-label={`${isExpanded ? 'Collapse' : 'Expand'} project: ${project.title}`}
                       onClick={() => toggleExpand(project.id)}
                       className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
                     >
@@ -372,6 +373,7 @@ export default function Plan() {
                               {/* Expand/Collapse */}
                               {hasSubtasks && (
                                 <button
+                                  aria-label={`${isTaskExpanded ? 'Collapse' : 'Expand'} task: ${task.title}`}
                                   onClick={() => toggleExpand(task.id)}
                                   className="text-gray-400 hover:text-gray-600"
                                 >

--- a/src/components/ui/task-plan.tsx
+++ b/src/components/ui/task-plan.tsx
@@ -175,6 +175,7 @@ export default function TaskPlan({
                   >
                     {task.subtasks.length > 0 && (
                       <button
+                        aria-label={`${isExpanded ? 'Collapse' : 'Expand'} task: ${task.title}`}
                         onClick={() => toggleTaskExpansion(task.id)}
                         className="mr-1 p-0.5 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
                       >


### PR DESCRIPTION
**💡 What:** Added explicit `aria-label`s to the icon-only expand/collapse buttons in nested list components (`agent-plan.tsx` and `task-plan.tsx`).
**🎯 Why:** Icon-only action buttons in trees or lists are ambiguous to screen reader users without context. Including the specific project or task title provides clear indication of what is being expanded or collapsed.
**♿ Accessibility:** Enhanced screen reader experience by interpolating the item's title into the `aria-label` (e.g., "Expand project: Learn React"). Also added this critical learning to the palette journal.

---
*PR created automatically by Jules for task [8464163156327810652](https://jules.google.com/task/8464163156327810652) started by @aryankumar06*