### PR TITLE
🎨 Palette: Add ARIA labels to close modal buttons

### DIFF
--- a/src/components/ReposView.tsx
+++ b/src/components/ReposView.tsx
@@ -264,6 +264,7 @@ export default function ReposView() {
             <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-neutral-800">
               <h3 className="text-lg font-bold dark:text-white">Select Repositories to Import</h3>
               <button 
+                aria-label="Close modal"
                 onClick={() => setShowImportModal(false)} 
                 className="text-gray-400 hover:text-gray-600"
               >

--- a/src/components/WorkspaceView.tsx
+++ b/src/components/WorkspaceView.tsx
@@ -938,7 +938,7 @@ function Modal({ onClose, title, children }: ModalProps) {
             <div className="bg-white dark:bg-neutral-900 w-full max-w-md rounded-2xl shadow-xl border border-gray-200 dark:border-neutral-800">
                 <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-neutral-800">
                     <h3 className="text-lg font-bold dark:text-white">{title}</h3>
-                    <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+                    <button aria-label="Close modal" onClick={onClose} className="text-gray-400 hover:text-gray-600">
                         <X className="w-5 h-5" />
                     </button>
                 </div>


### PR DESCRIPTION
💡 **What**: Added `aria-label="Close modal"` to icon-only close buttons in the Workspace and Repository import modal components.
🎯 **Why**: To improve accessibility for screen reader users by explicitly stating the button's action. 
📸 **Before/After**: No visual changes.
♿ **Accessibility**: Provides necessary context for screen reader users when navigating the modal dialogs.

---
*PR created automatically by Jules for task [6147952602709027698](https://jules.google.com/task/6147952602709027698) started by @aryankumar06*