### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons in Agent Plan

### DIFF
--- a/src/components/ui/agent-plan.tsx
+++ b/src/components/ui/agent-plan.tsx
@@ -243,6 +243,8 @@ export default function Plan() {
                     <button
                       onClick={() => toggleExpand(project.id)}
                       className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+                      aria-label={isExpanded ? `Collapse project: ${project.title}` : `Expand project: ${project.title}`}
+                      title={isExpanded ? "Collapse project" : "Expand project"}
                     >
                       {isExpanded ? <ChevronDown className="w-5 h-5" /> : <ChevronRight className="w-5 h-5" />}
                     </button>
@@ -252,6 +254,8 @@ export default function Plan() {
                   <motion.button
                     onClick={() => toggleStatus(project.id, project.status)}
                     className="flex-shrink-0 hover:opacity-80 transition-opacity"
+                    aria-label={project.status === 'completed' ? `Mark project incomplete: ${project.title}` : `Mark project complete: ${project.title}`}
+                    title={project.status === 'completed' ? "Mark project incomplete" : "Mark project complete"}
                   >
                     <AnimatePresence mode="wait">
                       <motion.div
@@ -374,6 +378,8 @@ export default function Plan() {
                                 <button
                                   onClick={() => toggleExpand(task.id)}
                                   className="text-gray-400 hover:text-gray-600"
+                                  aria-label={isTaskExpanded ? `Collapse task: ${task.title}` : `Expand task: ${task.title}`}
+                                  title={isTaskExpanded ? "Collapse task" : "Expand task"}
                                 >
                                   {isTaskExpanded ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
                                 </button>
@@ -383,6 +389,8 @@ export default function Plan() {
                               <motion.button
                                 onClick={() => toggleStatus(task.id, task.status)}
                                 className="flex-shrink-0 hover:opacity-80 transition-opacity"
+                                aria-label={task.status === 'completed' ? `Mark task incomplete: ${task.title}` : `Mark task complete: ${task.title}`}
+                                title={task.status === 'completed' ? "Mark task incomplete" : "Mark task complete"}
                               >
                                 <AnimatePresence mode="wait">
                                   <motion.div
@@ -486,6 +494,8 @@ export default function Plan() {
                                       <motion.button
                                         onClick={() => toggleStatus(subtask.id, subtask.status)}
                                         className="flex-shrink-0 hover:opacity-80 transition-opacity"
+                                        aria-label={subtask.status === 'completed' ? `Mark subtask incomplete: ${subtask.title}` : `Mark subtask complete: ${subtask.title}`}
+                                        title={subtask.status === 'completed' ? "Mark subtask incomplete" : "Mark subtask complete"}
                                       >
                                         <AnimatePresence mode="wait">
                                           <motion.div


### PR DESCRIPTION
**💡 What:** Added explicit `aria-label` and `title` attributes to the icon-only Expand/Collapse and Status toggle buttons in the Agent Plan component (`src/components/ui/agent-plan.tsx`).

**🎯 Why:** Screen readers and keyboard-only users could not easily distinguish between the different Expand/Collapse and Complete/Incomplete status toggle buttons in the nested project and task views, as they were only visual icons. Adding dynamic `aria-label`s and `title`s based on the item's current state and title provides crucial context for accessibility and tooltips for mouse users.

**📸 Before/After:** N/A (Invisible DOM attribute changes only, no visual difference besides native browser tooltips on hover).

**♿ Accessibility:**
- Added explicit `aria-label="Expand project: [Title]"` / `aria-label="Collapse project: [Title]"` to the expand/collapse buttons for projects and tasks.
- Added explicit `aria-label="Mark project complete: [Title]"` / `aria-label="Mark project incomplete: [Title]"` to the status toggle buttons for projects, tasks, and subtasks.
- Added corresponding native `title` attributes for on-hover tooltips.

---
*PR created automatically by Jules for task [4494896508579671938](https://jules.google.com/task/4494896508579671938) started by @aryankumar06*