### PR TITLE
🎨 Palette: Add aria-label to expand/collapse buttons

### DIFF
--- a/src/components/ui/agent-plan.tsx
+++ b/src/components/ui/agent-plan.tsx
@@ -241,6 +241,7 @@ export default function Plan() {
                   {/* Expand/Collapse */}
                   {hasChildren && (
                     <button
+                      aria-label={isExpanded ? `Collapse project: ${project.title}` : `Expand project: ${project.title}`}
                       onClick={() => toggleExpand(project.id)}
                       className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
                     >
@@ -372,6 +373,7 @@ export default function Plan() {
                               {/* Expand/Collapse */}
                               {hasSubtasks && (
                                 <button
+                                  aria-label={isTaskExpanded ? `Collapse task: ${task.title}` : `Expand task: ${task.title}`}
                                   onClick={() => toggleExpand(task.id)}
                                   className="text-gray-400 hover:text-gray-600"
                                 >


### PR DESCRIPTION
💡 **What:** Added dynamic `aria-label`s to the expand and collapse buttons within the project and task lists in the `agent-plan.tsx` component.
🎯 **Why:** To provide crucial context for screen reader users when interacting with these icon-only buttons.
📸 **Before/After:** No visual changes.
♿ **Accessibility:** The `aria-label` values now indicate whether the button expands or collapses the section, and they include the specific project or task title to differentiate between multiple similar buttons on the page.

---
*PR created automatically by Jules for task [18254992798475681099](https://jules.google.com/task/18254992798475681099) started by @aryankumar06*