### PR TITLE
🎨 Palette: Add accessibility attributes to expand/collapse buttons

### DIFF
--- a/src/components/ui/agent-plan.tsx
+++ b/src/components/ui/agent-plan.tsx
@@ -242,6 +242,8 @@ export default function Plan() {
                   {hasChildren && (
                     <button
                       onClick={() => toggleExpand(project.id)}
+                      aria-expanded={isExpanded}
+                      aria-label={`${isExpanded ? 'Collapse' : 'Expand'} project: ${project.title}`}
                       className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
                     >
                       {isExpanded ? <ChevronDown className="w-5 h-5" /> : <ChevronRight className="w-5 h-5" />}
@@ -373,6 +375,8 @@ export default function Plan() {
                               {hasSubtasks && (
                                 <button
                                   onClick={() => toggleExpand(task.id)}
+                                  aria-expanded={isTaskExpanded}
+                                  aria-label={`${isTaskExpanded ? 'Collapse' : 'Expand'} task: ${task.title}`}
                                   className="text-gray-400 hover:text-gray-600"
                                 >
                                   {isTaskExpanded ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}


### PR DESCRIPTION
**What:**
Added `aria-expanded` and descriptive `aria-label` attributes to the project and task expand/collapse icon buttons in the agent plan component.

**Why:**
The expand/collapse buttons for projects and tasks were icon-only (using Lucide chevron icons) without any accessible names or state indicators. This made them invisible or unhelpful to screen reader users, who would not know the purpose of the buttons or whether the item was currently expanded or collapsed. By adding these attributes, screen readers can accurately convey the button's action, its current state, and the specific item it controls.

**Before/After:**
*Before:* `<button onClick={...}><ChevronDown /></button>`
*After:* `<button onClick={...} aria-expanded={isExpanded} aria-label="Collapse project: Project Name"><ChevronDown /></button>` (Visual UI remains unchanged).

**Accessibility:**
- Added `aria-expanded` to communicate the open/closed state of the collapsible content.
- Added dynamic `aria-label` that includes the action ("Expand" or "Collapse"), the item type ("project" or "task"), and the item's title for crucial context.

---
*PR created automatically by Jules for task [10135049232884399384](https://jules.google.com/task/10135049232884399384) started by @aryankumar06*