### PR TITLE
🎨 Palette: [Add Project Button Accessibility]

### DIFF
--- a/src/components/DittoDashboard.tsx
+++ b/src/components/DittoDashboard.tsx
@@ -45,6 +45,8 @@ export default function DittoDashboard() {
         <button
           onClick={() => setShowAddForm(!showAddForm)}
           className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors font-medium"
+          aria-expanded={showAddForm}
+          aria-controls="add-project-form"
         >
           <Plus className="w-4 h-4" />
           {showAddForm ? 'Cancel' : 'Add Project'}
@@ -55,6 +57,7 @@ export default function DittoDashboard() {
       <AnimatePresence>
         {showAddForm && (
           <motion.div
+            id="add-project-form"
             initial={{ opacity: 0, height: 0 }}
             animate={{ opacity: 1, height: 'auto' }}
             exit={{ opacity: 0, height: 0 }}


### PR DESCRIPTION
💡 What: Added `aria-expanded` and `aria-controls` to the "Add Project" button in the DittoDashboard component.
🎯 Why: Improves accessibility for screen reader users by properly indicating when the associated form is visible and linking the trigger to the form container.
📸 Before/After: Not applicable (accessibility enhancement without visual changes).
♿ Accessibility: Ensures that disclosure widgets (like the "Add Project" expand/collapse form) correctly communicate their state and target area via ARIA attributes.

---
*PR created automatically by Jules for task [11834140796877824582](https://jules.google.com/task/11834140796877824582) started by @aryankumar06*