### PR TITLE
🎨 Palette: Add accessibility attributes to task form toggle

### DIFF
--- a/src/components/TaskSection.tsx
+++ b/src/components/TaskSection.tsx
@@ -313,6 +313,8 @@ export default function TaskSection({ selectedDate }: TaskSectionProps) {
 
         <button
           onClick={() => setShowForm(!showForm)}
+          aria-expanded={showForm}
+          aria-controls="add-task-form"
           className="flex items-center justify-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors font-medium"
         >
           <Plus className="w-4 h-4" />
@@ -329,6 +331,7 @@ export default function TaskSection({ selectedDate }: TaskSectionProps) {
       <AnimatePresence mode="wait">
         {showForm && (
           <motion.form 
+            id="add-task-form"
             onSubmit={handleSubmit} 
             className="mb-6 p-4 bg-gray-50 dark:bg-neutral-900/30 rounded-lg space-y-4"
             initial={{ opacity: 0, height: 0 }}


### PR DESCRIPTION
**💡 What:** Added `aria-expanded` and `aria-controls` to the "Add Task" / "Close Form" button in the Task Section, and linked it to an `id` on the form container it expands/collapses.

**🎯 Why:** Screen reader users needed a way to know if the form is currently expanded or collapsed, and which content area the button controls. Without these attributes, it was an ambiguous toggle button. This small change makes the interface a lot more accessible.

**📸 Before/After:** Invisible visual change.

**♿ Accessibility:** Enhanced the disclosure widget by exposing its state to assistive technologies, making it fully accessible and intuitive.

---
*PR created automatically by Jules for task [1181649818356886051](https://jules.google.com/task/1181649818356886051) started by @aryankumar06*