### PR TITLE
🎨 Palette: [UX improvement] Add ARIA attributes to Add Project toggle

### DIFF
--- a/src/components/DittoDashboard.tsx
+++ b/src/components/DittoDashboard.tsx
@@ -44,6 +44,8 @@ export default function DittoDashboard() {
       <div className="mb-6 flex items-center justify-end">
         <button
           onClick={() => setShowAddForm(!showAddForm)}
+          aria-expanded={showAddForm}
+          aria-controls="add-project-form"
           className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors font-medium"
         >
           <Plus className="w-4 h-4" />
@@ -55,6 +57,7 @@ export default function DittoDashboard() {
       <AnimatePresence>
         {showAddForm && (
           <motion.div
+            id="add-project-form"
             initial={{ opacity: 0, height: 0 }}
             animate={{ opacity: 1, height: 'auto' }}
             exit={{ opacity: 0, height: 0 }}


### PR DESCRIPTION
💡 What: Added `aria-expanded` and `aria-controls` to the 'Add Project' toggle button, and a matching `id` to the expanding form container in `src/components/DittoDashboard.tsx`.
🎯 Why: Makes the add project form functionally recognizable as a disclosure widget for screen readers, allowing users relying on assistive tech to understand the button controls the visibility of a related section.
📸 Before/After: This is an invisible DOM-only change.
♿ Accessibility: Improves widget structure and standardizes the toggle functionality per WAI-ARIA guidelines for expanding content regions.

---
*PR created automatically by Jules for task [15360800670590567139](https://jules.google.com/task/15360800670590567139) started by @aryankumar06*