### PR TITLE
🎨 Palette: Add accessibility attributes for expanding forms

### DIFF
--- a/src/components/DittoDashboard.tsx
+++ b/src/components/DittoDashboard.tsx
@@ -44,6 +44,8 @@ export default function DittoDashboard() {
       <div className="mb-6 flex items-center justify-end">
         <button
           onClick={() => setShowAddForm(!showAddForm)}
+          aria-expanded={showAddForm}
+          aria-controls="add-project-form"
           className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors font-medium"
         >
           <Plus className="w-4 h-4" />
@@ -55,6 +57,7 @@ export default function DittoDashboard() {
       <AnimatePresence>
         {showAddForm && (
           <motion.div
+            id="add-project-form"
             initial={{ opacity: 0, height: 0 }}
             animate={{ opacity: 1, height: 'auto' }}
             exit={{ opacity: 0, height: 0 }}

--- a/src/components/EventSection.tsx
+++ b/src/components/EventSection.tsx
@@ -133,6 +133,8 @@ export default function EventSection({ selectedDate }: EventSectionProps) {
         </h2>
         <button
           onClick={() => setShowForm(!showForm)}
+          aria-expanded={showForm}
+          aria-controls="add-event-form"
           className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors"
         >
           <Plus className="w-4 h-4" />
@@ -141,7 +143,7 @@ export default function EventSection({ selectedDate }: EventSectionProps) {
       </div>
 
       {showForm && (
-        <form onSubmit={handleSubmit} className="mb-6 p-4 bg-gray-50 dark:bg-neutral-900/30 rounded-lg space-y-4">
+        <form id="add-event-form" onSubmit={handleSubmit} className="mb-6 p-4 bg-gray-50 dark:bg-neutral-900/30 rounded-lg space-y-4">
           <input
             type="text"
             placeholder="Event title"

--- a/src/components/TaskSection.tsx
+++ b/src/components/TaskSection.tsx
@@ -313,6 +313,8 @@ export default function TaskSection({ selectedDate }: TaskSectionProps) {
 
         <button
           onClick={() => setShowForm(!showForm)}
+          aria-expanded={showForm}
+          aria-controls="add-task-form"
           className="flex items-center justify-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors font-medium"
         >
           <Plus className="w-4 h-4" />
@@ -329,6 +331,7 @@ export default function TaskSection({ selectedDate }: TaskSectionProps) {
       <AnimatePresence mode="wait">
         {showForm && (
           <motion.form 
+            id="add-task-form"
             onSubmit={handleSubmit} 
             className="mb-6 p-4 bg-gray-50 dark:bg-neutral-900/30 rounded-lg space-y-4"
             initial={{ opacity: 0, height: 0 }}


### PR DESCRIPTION
**💡 What:** 
Added `aria-expanded` and `aria-controls` attributes to the buttons that toggle the "Add Project", "Add Task", and "Add Event" forms, and assigned corresponding `id`s to the forms themselves.

**🎯 Why:** 
To improve accessibility for screen reader users. Previously, screen readers had no way to know that these buttons controlled an expanding section, nor could they easily determine if the section was currently visible.

**📸 Before/After:** 
Visual changes are non-existent; this is a purely structural/accessibility update.

**♿ Accessibility:** 
Screen readers will now properly announce the expanded/collapsed state of these forms and programmatically associate the toggle buttons with the content they reveal, significantly improving the experience for visually impaired users navigating the dashboards.

---
*PR created automatically by Jules for task [14096118932566434710](https://jules.google.com/task/14096118932566434710) started by @aryankumar06*