### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/src/components/EventSection.tsx
+++ b/src/components/EventSection.tsx
@@ -223,6 +223,7 @@ export default function EventSection({ selectedDate }: EventSectionProps) {
                 </div>
                 <div className="flex items-center gap-1">
                   <button
+                    aria-label={`Edit event: ${event.title}`}
                     onClick={() => handleEdit(event)}
                     className="p-2 text-gray-400 dark:text-gray-500 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-blue-50 dark:hover:bg-neutral-800 rounded transition-colors"
                   >

--- a/src/components/WorkspaceView.tsx
+++ b/src/components/WorkspaceView.tsx
@@ -938,7 +938,7 @@ function Modal({ onClose, title, children }: ModalProps) {
             <div className="bg-white dark:bg-neutral-900 w-full max-w-md rounded-2xl shadow-xl border border-gray-200 dark:border-neutral-800">
                 <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-neutral-800">
                     <h3 className="text-lg font-bold dark:text-white">{title}</h3>
-                    <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+                    <button aria-label="Close modal" onClick={onClose} className="text-gray-400 hover:text-gray-600">
                         <X className="w-5 h-5" />
                     </button>
                 </div>


### PR DESCRIPTION
### 💡 What
Added explicit `aria-label` attributes to icon-only buttons (Edit Event and Close Modal).

### 🎯 Why
Screen reader users need clear context when encountering buttons that only contain icons. Without these labels, screen readers may announce generic or unhelpful text, making the interface difficult to navigate and use.

### 📸 Before/After
*(No visual changes, as this is an accessibility enhancement)*

### ♿ Accessibility
- Improved screen reader support for the event editing action by explicitly identifying the event being edited.
- Improved modal navigation by clearly labeling the close button.

---
*PR created automatically by Jules for task [12869068576564362910](https://jules.google.com/task/12869068576564362910) started by @aryankumar06*