### PR TITLE
🎨 Palette: Improve accessibility of Add Project form

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,6 @@
 ## 2026-06-08 - Explicit Context for Icon-Only Action Buttons in Lists
 **Learning:** Icon-only action buttons (like Delete) in nested lists or trees without the item's context in the aria-label are ambiguous to screen reader users.
 **Action:** When adding icon-only action buttons to items in lists, always include the specific item's title in the `aria-label` (e.g., `aria-label="Delete task: [Task Title]"`) to provide explicit context.
+## 2024-07-22 - Custom Button Group Selector Accessibility
+**Learning:** Custom button groups that function as mutually exclusive selectors (like a Priority toggle) are opaque to screen readers if they lack semantic grouping and state.
+**Action:** When building custom toggle groups, always use `role="group"` and `aria-labelledby` on the group container, and indicate the active state using `aria-pressed` on the individual buttons.

--- a/src/components/DittoDashboard.tsx
+++ b/src/components/DittoDashboard.tsx
@@ -44,6 +44,8 @@ export default function DittoDashboard() {
       <div className="mb-6 flex items-center justify-end">
         <button
           onClick={() => setShowAddForm(!showAddForm)}
+          aria-expanded={showAddForm}
+          aria-controls="add-project-form"
           className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors font-medium"
         >
           <Plus className="w-4 h-4" />
@@ -55,6 +57,7 @@ export default function DittoDashboard() {
       <AnimatePresence>
         {showAddForm && (
           <motion.div
+            id="add-project-form"
             initial={{ opacity: 0, height: 0 }}
             animate={{ opacity: 1, height: 'auto' }}
             exit={{ opacity: 0, height: 0 }}
@@ -63,10 +66,11 @@ export default function DittoDashboard() {
             <div className="bg-white dark:bg-neutral-800 rounded-xl shadow-sm border border-gray-200 dark:border-neutral-700 p-6">
               <div className="space-y-4">
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                  <label htmlFor="project-title-input" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                     Project Title *
                   </label>
                   <input
+                    id="project-title-input"
                     type="text"
                     value={newProjectTitle}
                     onChange={(e) => setNewProjectTitle(e.target.value)}
@@ -83,10 +87,11 @@ export default function DittoDashboard() {
                 </div>
 
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                  <label htmlFor="project-desc-input" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                     Description
                   </label>
                   <textarea
+                    id="project-desc-input"
                     value={newProjectDescription}
                     onChange={(e) => setNewProjectDescription(e.target.value)}
                     placeholder="Enter project description..."
@@ -96,14 +101,15 @@ export default function DittoDashboard() {
                 </div>
 
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                  <label id="priority-label" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                     Priority
                   </label>
-                  <div className="flex gap-2">
+                  <div role="group" aria-labelledby="priority-label" className="flex gap-2">
                     {(['low', 'medium', 'high'] as const).map((priority) => (
                       <button
                         key={priority}
                         onClick={() => setNewProjectPriority(priority)}
+                        aria-pressed={newProjectPriority === priority}
                         className={`px-4 py-2 rounded-lg font-medium transition-colors ${
                           newProjectPriority === priority
                             ? priority === 'high'


### PR DESCRIPTION
💡 **What:** Improved the accessibility of the "Add Project" form in the `DittoDashboard` component.
🎯 **Why:** To make the form controls and dynamic disclosures more robust and understandable for screen reader users. Specifically, screen readers now properly announce when the form is expanded/collapsed, inputs are correctly associated with their labels, and the priority selector correctly announces the currently selected priority.
📸 **Before/After:** Not applicable (no visual changes).
♿ **Accessibility:**
- Added `aria-expanded` and `aria-controls` to the main disclosure toggle button.
- Connected labels to inputs via `htmlFor` and `id`.
- Upgraded the custom Priority button selector to use `role="group"`, `aria-labelledby`, and `aria-pressed` to correctly indicate mutually-exclusive selected state.

---
*PR created automatically by Jules for task [4583628211532425374](https://jules.google.com/task/4583628211532425374) started by @aryankumar06*