### PR TITLE
🎨 Palette: Improve accessibility for project creation disclosure and priority group

### DIFF
--- a/src/components/DittoDashboard.tsx
+++ b/src/components/DittoDashboard.tsx
@@ -45,6 +45,8 @@ export default function DittoDashboard() {
         <button
           onClick={() => setShowAddForm(!showAddForm)}
           className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors font-medium"
+          aria-expanded={showAddForm}
+          aria-controls="add-project-form"
         >
           <Plus className="w-4 h-4" />
           {showAddForm ? 'Cancel' : 'Add Project'}
@@ -55,6 +57,7 @@ export default function DittoDashboard() {
       <AnimatePresence>
         {showAddForm && (
           <motion.div
+            id="add-project-form"
             initial={{ opacity: 0, height: 0 }}
             animate={{ opacity: 1, height: 'auto' }}
             exit={{ opacity: 0, height: 0 }}
@@ -96,13 +99,15 @@ export default function DittoDashboard() {
                 </div>
 
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                  <label id="priority-label" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                     Priority
                   </label>
-                  <div className="flex gap-2">
+                  <div role="group" aria-labelledby="priority-label" className="flex gap-2">
                     {(['low', 'medium', 'high'] as const).map((priority) => (
                       <button
                         key={priority}
+                        type="button"
+                        aria-pressed={newProjectPriority === priority}
                         onClick={() => setNewProjectPriority(priority)}
                         className={`px-4 py-2 rounded-lg font-medium transition-colors ${
                           newProjectPriority === priority


### PR DESCRIPTION
💡 **What:** Added comprehensive ARIA accessibility attributes to the project creation disclosure widget and the custom "Priority" radio button group in the DittoDashboard component.

🎯 **Why:** Custom UI controls built with standard elements (`<button>`, `<div>`) often lack semantic meaning for screen readers. By adding `aria-expanded` and `aria-controls` to the toggle button, visually impaired users can now understand when the form opens and what it controls. Furthermore, transforming the visual "Priority" layout into a semantic `role="group"` with `aria-pressed` buttons ensures the form behaves like a proper, keyboard-accessible radio group. Adding `type="button"` also prevents unintended form submission behavior.

📸 **Before/After:**
*(Visuals remain identical, changes are strictly at the DOM accessibility layer)*

♿ **Accessibility:**
- Added `aria-expanded` and `aria-controls` to the "Add Project" button.
- Added `id="add-project-form"` to the conditionally rendered form container.
- Wrapped priority buttons in a `role="group"` with an `aria-labelledby` linking back to the "Priority" label.
- Added `type="button"` and `aria-pressed` state to individual priority selection buttons.

---
*PR created automatically by Jules for task [4368284708712399660](https://jules.google.com/task/4368284708712399660) started by @aryankumar06*