### PR TITLE
🎨 Palette: Improve accessibility of Add Project form

### DIFF
--- a/src/components/DittoDashboard.tsx
+++ b/src/components/DittoDashboard.tsx
@@ -44,6 +44,8 @@ export default function DittoDashboard() {
       <div className="mb-6 flex items-center justify-end">
         <button
           onClick={() => setShowAddForm(!showAddForm)}
+          aria-expanded={showAddForm}
+          aria-controls="add-project-form"
           className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors font-medium"
         >
           <Plus className="w-4 h-4" />
@@ -55,6 +57,7 @@ export default function DittoDashboard() {
       <AnimatePresence>
         {showAddForm && (
           <motion.div
+            id="add-project-form"
             initial={{ opacity: 0, height: 0 }}
             animate={{ opacity: 1, height: 'auto' }}
             exit={{ opacity: 0, height: 0 }}
@@ -96,13 +99,15 @@ export default function DittoDashboard() {
                 </div>
 
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                  <label id="priority-label" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                     Priority
                   </label>
-                  <div className="flex gap-2">
+                  <div className="flex gap-2" role="group" aria-labelledby="priority-label">
                     {(['low', 'medium', 'high'] as const).map((priority) => (
                       <button
                         key={priority}
+                        type="button"
+                        aria-pressed={newProjectPriority === priority}
                         onClick={() => setNewProjectPriority(priority)}
                         className={`px-4 py-2 rounded-lg font-medium transition-colors ${
                           newProjectPriority === priority


### PR DESCRIPTION
💡 What: Added accessibility attributes to the "Add Project" form in DittoDashboard.
🎯 Why: Makes the form fully compatible with screen readers. The "Add Project" button now correctly identifies as an expandable section trigger, and the priority selection buttons are properly identified as a group of mutually exclusive options.
📸 Before/After: N/A (Visual changes only)
♿ Accessibility: 
- Added `aria-expanded` and `aria-controls` to the "Add Project" button to link it to the collapsible form.
- Added `id="add-project-form"` to the collapsible form.
- Added `id="priority-label"` to the priority label, `role="group"` and `aria-labelledby` to the priority buttons container.
- Added `aria-pressed` to the individual priority buttons to indicate selection state, and `type="button"` to prevent unintended form submissions.

---
*PR created automatically by Jules for task [6874574146331228156](https://jules.google.com/task/6874574146331228156) started by @aryankumar06*