### PR TITLE
🎨 Palette: Add accessible group role to priority selector

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,6 @@
 ## 2026-06-08 - Explicit Context for Icon-Only Action Buttons in Lists
 **Learning:** Icon-only action buttons (like Delete) in nested lists or trees without the item's context in the aria-label are ambiguous to screen reader users.
 **Action:** When adding icon-only action buttons to items in lists, always include the specific item's title in the `aria-label` (e.g., `aria-label="Delete task: [Task Title]"`) to provide explicit context.
+## 2024-05-14 - Accessible Radio Button Replacements
+**Learning:** For custom button groups that function as mutually exclusive selectors (like Priority), screen readers don't natively understand they are related or which is selected unless explicitly told.
+**Action:** Use `role="group"` with `aria-labelledby` on the container, and `type="button"` with `aria-pressed={isSelected}` on the individual buttons to create an accessible radio-button-like experience.

--- a/src/components/DittoDashboard.tsx
+++ b/src/components/DittoDashboard.tsx
@@ -96,13 +96,15 @@ export default function DittoDashboard() {
                 </div>
 
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                  <label id="priority-label" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                     Priority
                   </label>
-                  <div className="flex gap-2">
+                  <div role="group" aria-labelledby="priority-label" className="flex gap-2">
                     {(['low', 'medium', 'high'] as const).map((priority) => (
                       <button
                         key={priority}
+                        type="button"
+                        aria-pressed={newProjectPriority === priority}
                         onClick={() => setNewProjectPriority(priority)}
                         className={`px-4 py-2 rounded-lg font-medium transition-colors ${
                           newProjectPriority === priority


### PR DESCRIPTION
💡 What: The UX enhancement added: Added `role="group"`, `aria-labelledby`, `type="button"`, and `aria-pressed` to the priority selector buttons in `DittoDashboard`.

🎯 Why: The user problem it solves: Screen readers don't natively understand that custom button groups functioning as mutually exclusive selectors are related or which one is currently selected unless explicitly told.

📸 Before/After: No visual changes, invisible accessibility improvements only.

♿ Accessibility: Any a11y improvements made: Improved screen reader support for the priority selector by making it function like an accessible radio button group. Added `type="button"` to prevent native form submission.

---
*PR created automatically by Jules for task [12120697639931560075](https://jules.google.com/task/12120697639931560075) started by @aryankumar06*