### PR TITLE
🎨 Palette: Make custom priority button group accessible

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-06-08 - Explicit Context for Icon-Only Action Buttons in Lists
 **Learning:** Icon-only action buttons (like Delete) in nested lists or trees without the item's context in the aria-label are ambiguous to screen reader users.
 **Action:** When adding icon-only action buttons to items in lists, always include the specific item's title in the `aria-label` (e.g., `aria-label="Delete task: [Task Title]"`) to provide explicit context.
+
+## 2024-07-30 - Custom Button Group Accessibility
+**Learning:** Custom button groups that function as mutually exclusive selectors are not accessible by default. Screen readers won't know they belong together or which one is selected.
+**Action:** Always use `role="group"` and `aria-labelledby` on the container of a custom button group, and add `aria-pressed` to indicate the selected state of the individual buttons. Additionally, ensure `type="button"` is present to avoid accidental form submissions.

--- a/src/components/DittoDashboard.tsx
+++ b/src/components/DittoDashboard.tsx
@@ -96,14 +96,16 @@ export default function DittoDashboard() {
                 </div>
 
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                  <label id="project-priority-label" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                     Priority
                   </label>
-                  <div className="flex gap-2">
+                  <div role="group" aria-labelledby="project-priority-label" className="flex gap-2">
                     {(['low', 'medium', 'high'] as const).map((priority) => (
                       <button
                         key={priority}
+                        type="button"
                         onClick={() => setNewProjectPriority(priority)}
+                        aria-pressed={newProjectPriority === priority}
                         className={`px-4 py-2 rounded-lg font-medium transition-colors ${
                           newProjectPriority === priority
                             ? priority === 'high'


### PR DESCRIPTION
**What:**
Added semantic accessibility attributes (`role="group"`, `aria-labelledby`, `aria-pressed`) and `type="button"` to the custom project priority selector button group in the Ditto Dashboard.

**Why:**
Custom button groups that act like radio buttons are not accessible by default. Screen reader users could tab through the low/medium/high buttons but wouldn't receive context that they belong together as a mutually exclusive choice, nor which one is currently selected.

**Accessibility:**
- Added `id="project-priority-label"` to the existing label and linked it to the button container using `aria-labelledby`.
- Added `role="group"` to the button container to semantically group the choices.
- Added `aria-pressed` dynamically to the individual buttons to announce the selected state.
- Added `type="button"` to prevent potential unintended form submissions.

---
*PR created automatically by Jules for task [6952796388825384185](https://jules.google.com/task/6952796388825384185) started by @aryankumar06*