### PR TITLE
🎨 Palette: Add accessible states to dashboard interactive elements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,11 @@
 ## 2026-06-08 - Explicit Context for Icon-Only Action Buttons in Lists
 **Learning:** Icon-only action buttons (like Delete) in nested lists or trees without the item's context in the aria-label are ambiguous to screen reader users.
 **Action:** When adding icon-only action buttons to items in lists, always include the specific item's title in the `aria-label` (e.g., `aria-label="Delete task: [Task Title]"`) to provide explicit context.
+
+## 2024-05-18 - Grouping and State for Custom Mutually Exclusive Selectors
+**Learning:** Custom styled buttons acting as mutually exclusive selectors (like priority buttons) are not automatically recognized by screen readers as a group, making their relationship and selected state unclear.
+**Action:** Always wrap such custom button groups with `role="group"` and `aria-labelledby`, and explicitly indicate the selected state of individual buttons using `aria-pressed`. Also, explicitly set `type="button"` to avoid accidental form submissions if wrapped in a form.
+
+## 2024-05-18 - ARIA Attributes for Expanding Forms
+**Learning:** Expanding forms toggled by buttons without explicit ARIA relationships are confusing for screen reader users as they do not know the button controls a section of the page or its current state.
+**Action:** When building collapsible sections or disclosure widgets (e.g., an expanding form toggled by a button), always use the `aria-expanded` attribute on the trigger button to indicate state, and the `aria-controls` attribute pointing to the controlled element's `id`.

--- a/src/components/DittoDashboard.tsx
+++ b/src/components/DittoDashboard.tsx
@@ -44,6 +44,8 @@ export default function DittoDashboard() {
       <div className="mb-6 flex items-center justify-end">
         <button
           onClick={() => setShowAddForm(!showAddForm)}
+          aria-expanded={showAddForm}
+          aria-controls="add-project-form"
           className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors font-medium"
         >
           <Plus className="w-4 h-4" />
@@ -55,6 +57,7 @@ export default function DittoDashboard() {
       <AnimatePresence>
         {showAddForm && (
           <motion.div
+            id="add-project-form"
             initial={{ opacity: 0, height: 0 }}
             animate={{ opacity: 1, height: 'auto' }}
             exit={{ opacity: 0, height: 0 }}
@@ -96,13 +99,15 @@ export default function DittoDashboard() {
                 </div>
 
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                  <label id="priority-label" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                     Priority
                   </label>
-                  <div className="flex gap-2">
+                  <div className="flex gap-2" role="group" aria-labelledby="priority-label">
                     {(['low', 'medium', 'high'] as const).map((priority) => (
                       <button
                         key={priority}
+                        type="button"
+                        aria-pressed={newProjectPriority === priority}
                         onClick={() => setNewProjectPriority(priority)}
                         className={`px-4 py-2 rounded-lg font-medium transition-colors ${
                           newProjectPriority === priority


### PR DESCRIPTION
💡 What: Added accessible states to dashboard interactive elements. Added `aria-expanded` and `aria-controls` to the "Add Project" button and an `id` to its corresponding form. Re-implemented the custom Priority selection buttons as an accessible button group using `role="group"`, `aria-labelledby`, `type="button"`, and `aria-pressed`.

🎯 Why: To make the application more accessible and robust for users using screen readers or keyboard navigation. Screen readers will now understand that the Add Project button opens a form, and they will be able to distinguish between priority selection options correctly.

📸 Before/After: Visual presentation remains exactly the same.

♿ Accessibility:
* Added `aria-expanded` and `aria-controls` to the Add Project button to communicate its role as an expanding disclosure toggle.
* Added `id` to the Add Project form motion.div.
* Added `role="group"` and `aria-labelledby` to the Priority selection container to indicate that the buttons act together.
* Added `type="button"` and `aria-pressed` to the priority buttons so their selection state and intended function are clear to screen reader users, and so they will not mistakenly submit wrapping forms.

---
*PR created automatically by Jules for task [13038877160354901921](https://jules.google.com/task/13038877160354901921) started by @aryankumar06*