### PR TITLE
🎨 Palette: Improve accessibility of task view mode toggle

### DIFF
--- a/src/components/TaskSection.tsx
+++ b/src/components/TaskSection.tsx
@@ -287,8 +287,14 @@ export default function TaskSection({ selectedDate }: TaskSectionProps) {
           <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">Tasks</h2>
           
           {/* View Mode Toggle - Simplified and explicit */}
-          <div className="flex items-center ml-2 bg-gray-100 dark:bg-neutral-800 rounded-lg p-1 border border-gray-200 dark:border-neutral-700">
+          <div
+            role="group"
+            aria-label="View mode"
+            className="flex items-center ml-2 bg-gray-100 dark:bg-neutral-800 rounded-lg p-1 border border-gray-200 dark:border-neutral-700"
+          >
             <button
+              type="button"
+              aria-pressed={viewMode === 'list'}
               onClick={() => setViewMode('list')}
               className={`px-3 py-1 rounded-md text-xs font-bold transition-all ${
                 viewMode === 'list' 
@@ -299,6 +305,8 @@ export default function TaskSection({ selectedDate }: TaskSectionProps) {
               List
             </button>
             <button
+              type="button"
+              aria-pressed={viewMode === 'plan'}
               onClick={() => setViewMode('plan')}
               className={`px-3 py-1 rounded-md text-xs font-bold transition-all ${
                 viewMode === 'plan' 


### PR DESCRIPTION
💡 **What:** Added missing ARIA attributes (`role="group"`, `aria-label`, and `aria-pressed`) and explicit `type="button"` to the view mode toggle in the Tasks section.
🎯 **Why:** To ensure screen readers can correctly identify the toggle buttons as a related group of mutually exclusive options, and announce which option is currently active. Adding `type="button"` prevents unintended form submissions if this component is ever nested inside a form.
📸 **Before/After:** No visual changes.
♿ **Accessibility:** The toggle is now explicitly announced as a group, and the selected state (List vs Plan) is programmatically communicated to assistive technologies.

---
*PR created automatically by Jules for task [7318917144530886794](https://jules.google.com/task/7318917144530886794) started by @aryankumar06*