### PR TITLE
🎨 Palette: Improve accessibility of user type selection buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,4 @@
 ## 2026-06-08 - Explicit Context for Icon-Only Action Buttons in Lists
 **Learning:** Icon-only action buttons (like Delete) in nested lists or trees without the item's context in the aria-label are ambiguous to screen reader users.
 **Action:** When adding icon-only action buttons to items in lists, always include the specific item's title in the `aria-label` (e.g., `aria-label="Delete task: [Task Title]"`) to provide explicit context.
+## 2026-08-03 - Explicit Group Context for Role Selections\n**Learning:** Custom selection buttons (like role choosers during signup) that function as a group can be confusing for screen reader users if they aren't explicitly grouped together with a label.\n**Action:** When creating custom radio-like button groups, use `role="group"` and `aria-labelledby` on the container, and use `aria-pressed` on individual buttons to indicate the selection state.

--- a/src/components/Auth.tsx
+++ b/src/components/Auth.tsx
@@ -526,10 +526,11 @@ export default function Auth() {
 
                 {isSignUp && (
                   <div className="space-y-2">
-                     <p className="text-xs text-gray-500">I am a...</p>
-                     <div className="grid grid-cols-3 gap-2">
+                     <p id="user-type-group-label" className="text-xs text-gray-500">I am a...</p>
+                     <div className="grid grid-cols-3 gap-2" role="group" aria-labelledby="user-type-group-label">
                         <button
                           type="button"
+                          aria-pressed={userType === 'student'}
                           onClick={() => setUserType('student')}
                           className={`p-3 border rounded-lg text-xs font-medium transition-all ${
                             userType === 'student'
@@ -541,6 +542,7 @@ export default function Auth() {
                         </button>
                         <button
                           type="button"
+                          aria-pressed={userType === 'professional'}
                           onClick={() => setUserType('professional')}
                           className={`p-3 border rounded-lg text-xs font-medium transition-all ${
                             userType === 'professional'
@@ -552,6 +554,7 @@ export default function Auth() {
                         </button>
                         <button
                           type="button"
+                          aria-pressed={userType === 'creator'}
                           onClick={() => setUserType('creator')}
                           className={`p-3 border rounded-lg text-xs font-medium transition-all ${
                             userType === 'creator'


### PR DESCRIPTION
💡 **What:** Improved the accessibility of the user type selection buttons ("I am a...") on the sign-up form. Added `role="group"`, `aria-labelledby`, and `aria-pressed` attributes.
🎯 **Why:** Screen reader users needed more context when navigating these custom selection buttons. Without a group role, it was unclear these buttons were related to the "I am a..." label, and without `aria-pressed`, the selection state was only conveyed visually.
📸 **Before/After:** No visual changes.
♿ **Accessibility:**
- Added an `id` to the label and connected it to the grid container using `aria-labelledby`.
- Applied `role="group"` to the grid container to group the buttons semantically.
- Used `aria-pressed` on each button to announce the active selected state.

---
*PR created automatically by Jules for task [21265894522737983](https://jules.google.com/task/21265894522737983) started by @aryankumar06*