### PR TITLE
🎨 Palette: Enhance Add Project form accessibility

### DIFF
--- a/src/components/DittoDashboard.tsx
+++ b/src/components/DittoDashboard.tsx
@@ -45,6 +45,8 @@ export default function DittoDashboard() {
         <button
           onClick={() => setShowAddForm(!showAddForm)}
           className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors font-medium"
+          aria-expanded={showAddForm}
+          aria-controls="add-project-form"
         >
           <Plus className="w-4 h-4" />
           {showAddForm ? 'Cancel' : 'Add Project'}
@@ -55,6 +57,7 @@ export default function DittoDashboard() {
       <AnimatePresence>
         {showAddForm && (
           <motion.div
+            id="add-project-form"
             initial={{ opacity: 0, height: 0 }}
             animate={{ opacity: 1, height: 'auto' }}
             exit={{ opacity: 0, height: 0 }}
@@ -96,13 +99,15 @@ export default function DittoDashboard() {
                 </div>
 
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                  <label id="priority-label" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                     Priority
                   </label>
-                  <div className="flex gap-2">
+                  <div className="flex gap-2" role="group" aria-labelledby="priority-label">
                     {(['low', 'medium', 'high'] as const).map((priority) => (
                       <button
                         key={priority}
+                        type="button"
+                        aria-pressed={newProjectPriority === priority}
                         onClick={() => setNewProjectPriority(priority)}
                         className={`px-4 py-2 rounded-lg font-medium transition-colors ${
                           newProjectPriority === priority


### PR DESCRIPTION
### 💡 What:
Added ARIA attributes and semantic types to the "Add Project" form and its priority selector buttons in the Ditto Dashboard.

### 🎯 Why:
This improves screen reader compatibility and keyboard navigation. Specifically, it announces the expanded/collapsed state of the add project form, properly links the priority buttons as a mutually exclusive radio group for screen readers, and ensures the priority buttons aren't mistakenly treated as form submit triggers by browsers.

### 📸 Before/After:
No visual changes. (Invisible accessibility improvements)

### ♿ Accessibility:
- Added `aria-expanded` and `aria-controls` to the "Add Project" toggle button, linked to the `id` of the form container.
- Wrapped the Priority buttons in a `role="group"` with an `aria-labelledby` linking to the "Priority" label.
- Added `type="button"` to the Priority buttons to prevent default form submission behavior.
- Added `aria-pressed` to the Priority buttons to explicitly announce the active selection state to assistive technologies.

---
*PR created automatically by Jules for task [8529995399335321487](https://jules.google.com/task/8529995399335321487) started by @aryankumar06*