### PR TITLE
🎨 Palette: [Productivity Style a11y group]

### DIFF
--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -203,13 +203,15 @@ export default function SettingsView() {
                             <Layout className="w-6 h-6" />
                         </div>
                         <div>
-                            <h3 className="text-lg font-semibold dark:text-white">Productivity Style</h3>
+                            <h3 id="productivity-style-heading" className="text-lg font-semibold dark:text-white">Productivity Style</h3>
                             <p className="text-sm text-gray-500 dark:text-gray-400">Choose the mode that best fits your workflow.</p>
                         </div>
                     </div>
 
-                    <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                    <div className="grid grid-cols-1 md:grid-cols-3 gap-4" role="group" aria-labelledby="productivity-style-heading">
                         <button
+                            type="button"
+                            aria-pressed={style === 'student'}
                             onClick={() => setStyle('student')}
                             className={`relative p-4 rounded-xl border-2 text-left transition-all ${
                                 style === 'student' 
@@ -223,6 +225,8 @@ export default function SettingsView() {
                         </button>
 
                         <button
+                            type="button"
+                            aria-pressed={style === 'professional'}
                             onClick={() => setStyle('professional')}
                             className={`relative p-4 rounded-xl border-2 text-left transition-all ${
                                 style === 'professional' 
@@ -236,6 +240,8 @@ export default function SettingsView() {
                         </button>
 
                         <button
+                            type="button"
+                            aria-pressed={style === 'creator'}
                             onClick={() => setStyle('creator')}
                             className={`relative p-4 rounded-xl border-2 text-left transition-all ${
                                 style === 'creator' 


### PR DESCRIPTION
**What:** 
Added `id` to the productivity style heading, `role="group"` and `aria-labelledby` to the surrounding container, and `type="button"` with `aria-pressed` to the individual mode selection buttons in the settings view.

**Why:** 
The productivity style buttons act as a mutually exclusive choice selector (a custom radio group). By adding these accessibility properties, we establish a semantic grouping that associates the buttons directly with the heading label. Screen readers can now properly announce the group name, the user's current selection, and what state the button is in when they interact with it.

**Before/After:**
*(Visuals remain unchanged. Screen readers will now announce "Productivity Style group" and "Student button, pressed" instead of an unassociated generic button)*

**Accessibility:**
- Added `role="group"` and `aria-labelledby` linking to the heading to explicitly group these related options together.
- Added `aria-pressed` dynamic state binding to allow assistive technologies to communicate the active selection.
- Added `type="button"` to ensure the options aren't interpreted as submit actions within any implicit forms.

---
*PR created automatically by Jules for task [16203010000660270189](https://jules.google.com/task/16203010000660270189) started by @aryankumar06*