### PR TITLE
🎨 Palette: Improve view mode toggle accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,6 @@
 ## 2026-06-08 - Explicit Context for Icon-Only Action Buttons in Lists
 **Learning:** Icon-only action buttons (like Delete) in nested lists or trees without the item's context in the aria-label are ambiguous to screen reader users.
 **Action:** When adding icon-only action buttons to items in lists, always include the specific item's title in the `aria-label` (e.g., `aria-label="Delete task: [Task Title]"`) to provide explicit context.
+## $(date +%Y-%m-%d) - View Mode Toggle Accessibility Improvement
+**Learning:** For custom view toggle button groups (e.g., list vs plan view), they function as mutually exclusive selectors and need proper ARIA attributes to be fully accessible to screen readers, instead of just simple styled buttons.
+**Action:** Always add `role="group"` and `aria-label` to the container, and use `aria-pressed={true/false}` on the individual buttons to indicate the selected state. Also ensure `type="button"` is used and focus states (`focus-visible`) are clearly defined for keyboard navigation.

--- a/src/components/TaskSection.tsx
+++ b/src/components/TaskSection.tsx
@@ -287,10 +287,12 @@ export default function TaskSection({ selectedDate }: TaskSectionProps) {
           <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">Tasks</h2>
           
           {/* View Mode Toggle - Simplified and explicit */}
-          <div className="flex items-center ml-2 bg-gray-100 dark:bg-neutral-800 rounded-lg p-1 border border-gray-200 dark:border-neutral-700">
+          <div className="flex items-center ml-2 bg-gray-100 dark:bg-neutral-800 rounded-lg p-1 border border-gray-200 dark:border-neutral-700" role="group" aria-label="View mode">
             <button
+              type="button"
               onClick={() => setViewMode('list')}
-              className={`px-3 py-1 rounded-md text-xs font-bold transition-all ${
+              aria-pressed={viewMode === 'list'}
+              className={`px-3 py-1 rounded-md text-xs font-bold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 focus-visible:ring-offset-gray-100 dark:focus-visible:ring-offset-neutral-800 ${
                 viewMode === 'list' 
                   ? 'bg-blue-600 text-white shadow-sm' 
                   : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
@@ -299,8 +301,10 @@ export default function TaskSection({ selectedDate }: TaskSectionProps) {
               List
             </button>
             <button
+              type="button"
               onClick={() => setViewMode('plan')}
-              className={`px-3 py-1 rounded-md text-xs font-bold transition-all ${
+              aria-pressed={viewMode === 'plan'}
+              className={`px-3 py-1 rounded-md text-xs font-bold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 focus-visible:ring-offset-gray-100 dark:focus-visible:ring-offset-neutral-800 ${
                 viewMode === 'plan' 
                   ? 'bg-blue-600 text-white shadow-sm' 
                   : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'


### PR DESCRIPTION
### What
Added appropriate ARIA roles, labels, and states to the view mode toggle in the `TaskSection` component, along with improved keyboard focus states.

### Why
The view mode toggle previously lacked the semantics for a mutually exclusive button group. This update ensures that screen reader users understand the component is a group of options ("View mode") and can discern which option is currently selected. Keyboard users also get clearer visual feedback on focus.

### Before/After
*(Visual changes only involve focus rings, otherwise visually identical)*

### Accessibility
- Added `role="group"` and `aria-label="View mode"` to the container.
- Added `type="button"` and `aria-pressed={true/false}` to individual toggle buttons.
- Enhanced keyboard accessibility by adding explicit `focus-visible` ring styles.

---
*PR created automatically by Jules for task [11302520328818933175](https://jules.google.com/task/11302520328818933175) started by @aryankumar06*