### PR TITLE
🎨 Palette: [a11y] Improve accessibility of View Mode toggle in TaskSection

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-06-08 - Explicit Context for Icon-Only Action Buttons in Lists
 **Learning:** Icon-only action buttons (like Delete) in nested lists or trees without the item's context in the aria-label are ambiguous to screen reader users.
 **Action:** When adding icon-only action buttons to items in lists, always include the specific item's title in the `aria-label` (e.g., `aria-label="Delete task: [Task Title]"`) to provide explicit context.
+
+## 2024-08-07 - Accessibility for Custom Button Groups
+**Learning:** Custom button groups that function as mutually exclusive selectors (like a view toggle) lack inherent semantic meaning and state indication for screen reader users compared to native radio buttons.
+**Action:** Always use `role="group"` and `aria-label` or `aria-labelledby` on the group container, and indicate the selected state using `aria-pressed` on the individual buttons. Add `type="button"` to prevent native form submissions, and ensure clear focus states (e.g., using `focus-visible` classes) for keyboard navigation.

--- a/src/components/TaskSection.tsx
+++ b/src/components/TaskSection.tsx
@@ -287,10 +287,16 @@ export default function TaskSection({ selectedDate }: TaskSectionProps) {
           <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">Tasks</h2>
           
           {/* View Mode Toggle - Simplified and explicit */}
-          <div className="flex items-center ml-2 bg-gray-100 dark:bg-neutral-800 rounded-lg p-1 border border-gray-200 dark:border-neutral-700">
+          <div
+            className="flex items-center ml-2 bg-gray-100 dark:bg-neutral-800 rounded-lg p-1 border border-gray-200 dark:border-neutral-700"
+            role="group"
+            aria-label="View Mode"
+          >
             <button
+              type="button"
               onClick={() => setViewMode('list')}
-              className={`px-3 py-1 rounded-md text-xs font-bold transition-all ${
+              aria-pressed={viewMode === 'list'}
+              className={`px-3 py-1 rounded-md text-xs font-bold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
                 viewMode === 'list' 
                   ? 'bg-blue-600 text-white shadow-sm' 
                   : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
@@ -299,8 +305,10 @@ export default function TaskSection({ selectedDate }: TaskSectionProps) {
               List
             </button>
             <button
+              type="button"
               onClick={() => setViewMode('plan')}
-              className={`px-3 py-1 rounded-md text-xs font-bold transition-all ${
+              aria-pressed={viewMode === 'plan'}
+              className={`px-3 py-1 rounded-md text-xs font-bold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
                 viewMode === 'plan' 
                   ? 'bg-blue-600 text-white shadow-sm' 
                   : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'


### PR DESCRIPTION
💡 What: Added ARIA labels, role="group", aria-pressed states, and focus-visible classes to the View Mode toggle in TaskSection.tsx.
🎯 Why: Custom button groups that function as mutually exclusive selectors lack semantic meaning and state indication for screen reader users and keyboard navigators compared to native radio buttons.
📸 Before/After: Visuals are unchanged (except for explicit focus rings during keyboard navigation).
♿ Accessibility:
- Added `role="group"` and `aria-label="View Mode"` to container.
- Added `type="button"` and `aria-pressed={boolean}` to individual toggle buttons.
- Added explicit `focus-visible` styles for better keyboard navigation visibility.

---
*PR created automatically by Jules for task [18336077148907186641](https://jules.google.com/task/18336077148907186641) started by @aryankumar06*