### PR TITLE
🎨 Palette: [Add ARIA states to dynamic forms]

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,6 @@
 ## 2026-06-08 - Explicit Context for Icon-Only Action Buttons in Lists
 **Learning:** Icon-only action buttons (like Delete) in nested lists or trees without the item's context in the aria-label are ambiguous to screen reader users.
 **Action:** When adding icon-only action buttons to items in lists, always include the specific item's title in the `aria-label` (e.g., `aria-label="Delete task: [Task Title]"`) to provide explicit context.
+## 2024-08-10 - ARIA Expanded and Controls for Dynamic Forms
+**Learning:** Collapsible forms toggled via buttons (e.g., "Add Task", "New Habit") need explicit semantic linkage so screen readers can announce state changes.
+**Action:** Always add `aria-expanded={state}` and `aria-controls="form-id"` to toggle buttons, and apply the corresponding `id="form-id"` to the form container.

--- a/src/components/HabitSection.tsx
+++ b/src/components/HabitSection.tsx
@@ -281,6 +281,8 @@ export default function HabitSection({ selectedDate }: HabitSectionProps) {
               <div className="ml-2">
                 <Button 
                     onClick={() => setShowForm(true)}
+                    aria-expanded={showForm}
+                    aria-controls="habit-form-modal"
                     className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-md flex items-center gap-2"
                 >
                   <span>New</span>
@@ -300,6 +302,7 @@ export default function HabitSection({ selectedDate }: HabitSectionProps) {
                     onClick={() => resetForm()}
                 >
                     <motion.div 
+                        id="habit-form-modal"
                         initial={{ scale: 0.95 }} animate={{ scale: 1 }} exit={{ scale: 0.95 }}
                         className="bg-[#191919] border border-[#333] rounded-xl shadow-2xl w-full max-w-md overflow-hidden p-6"
                         onClick={e => e.stopPropagation()}

--- a/src/components/TaskSection.tsx
+++ b/src/components/TaskSection.tsx
@@ -313,6 +313,8 @@ export default function TaskSection({ selectedDate }: TaskSectionProps) {
 
         <button
           onClick={() => setShowForm(!showForm)}
+          aria-expanded={showForm}
+          aria-controls="task-form-panel"
           className="flex items-center justify-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors font-medium"
         >
           <Plus className="w-4 h-4" />
@@ -329,6 +331,7 @@ export default function TaskSection({ selectedDate }: TaskSectionProps) {
       <AnimatePresence mode="wait">
         {showForm && (
           <motion.form 
+            id="task-form-panel"
             onSubmit={handleSubmit} 
             className="mb-6 p-4 bg-gray-50 dark:bg-neutral-900/30 rounded-lg space-y-4"
             initial={{ opacity: 0, height: 0 }}


### PR DESCRIPTION
* 💡 What: Added `aria-expanded` and `aria-controls` to the "New Habit" and "Add Task" buttons, and linked them via `id` to their respective form containers.
* 🎯 Why: To properly communicate the relationship and state of these collapsible modal sections to screen reader users.
* 📸 Before/After: N/A (Invisible DOM structure change)
* ♿ Accessibility: Improves screen reader context by explicitly linking toggle buttons to the content they control and indicating their current expanded/collapsed state.

---
*PR created automatically by Jules for task [5656336361616111732](https://jules.google.com/task/5656336361616111732) started by @aryankumar06*