### PR TITLE
🎨 Palette: [UX improvement] Accessible View Mode Toggle

### DIFF
--- a/src/components/TaskSection.tsx
+++ b/src/components/TaskSection.tsx
@@ -287,10 +287,16 @@ export default function TaskSection({ selectedDate }: TaskSectionProps) {
           <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">Tasks</h2>
           
           {/* View Mode Toggle - Simplified and explicit */}
-          <div className="flex items-center ml-2 bg-gray-100 dark:bg-neutral-800 rounded-lg p-1 border border-gray-200 dark:border-neutral-700">
+          <div
+            role="group"
+            aria-label="View mode"
+            className="flex items-center ml-2 bg-gray-100 dark:bg-neutral-800 rounded-lg p-1 border border-gray-200 dark:border-neutral-700"
+          >
             <button
+              type="button"
+              aria-pressed={viewMode === 'list'}
               onClick={() => setViewMode('list')}
-              className={`px-3 py-1 rounded-md text-xs font-bold transition-all ${
+              className={`px-3 py-1 rounded-md text-xs font-bold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
                 viewMode === 'list' 
                   ? 'bg-blue-600 text-white shadow-sm' 
                   : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
@@ -299,8 +305,10 @@ export default function TaskSection({ selectedDate }: TaskSectionProps) {
               List
             </button>
             <button
+              type="button"
+              aria-pressed={viewMode === 'plan'}
               onClick={() => setViewMode('plan')}
-              className={`px-3 py-1 rounded-md text-xs font-bold transition-all ${
+              className={`px-3 py-1 rounded-md text-xs font-bold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
                 viewMode === 'plan' 
                   ? 'bg-blue-600 text-white shadow-sm' 
                   : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'


### PR DESCRIPTION
💡 What: Added ARIA roles and keyboard focus styles to the view mode toggle in TaskSection.tsx.
🎯 Why: The previous toggle buttons were not properly grouped and lacked explicit semantic states, making it harder for screen reader users to understand their relationship and current selection. Additionally, the buttons did not have clear focus rings when navigating via keyboard.
📸 Before/After: Visual change is subtle, focusing on a more distinct blue focus ring (`focus-visible:ring-blue-500`) when tabbing through the UI.
♿ Accessibility: 
- Added `role="group"` and `aria-label="View mode"` to the container.
- Added `aria-pressed` to indicate the currently active mode (List vs Plan).
- Added `type="button"` to explicitly define the behavior.
- Added Tailwind `focus-visible` classes to ensure visible outlines during keyboard navigation.

---
*PR created automatically by Jules for task [16345722033408742106](https://jules.google.com/task/16345722033408742106) started by @aryankumar06*