### PR TITLE
🎨 Palette: Improve accessibility for Productivity Style selector

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,6 @@
 ## 2026-06-08 - Explicit Context for Icon-Only Action Buttons in Lists
 **Learning:** Icon-only action buttons (like Delete) in nested lists or trees without the item's context in the aria-label are ambiguous to screen reader users.
 **Action:** When adding icon-only action buttons to items in lists, always include the specific item's title in the `aria-label` (e.g., `aria-label="Delete task: [Task Title]"`) to provide explicit context.
+## 2025-02-12 - Explicit Roles for Mutually Exclusive Selectors
+**Learning:** Mutually exclusive button groups used for selection (like segmented controls) need proper ARIA roles to be understood as a group by screen readers, rather than individual disjointed buttons.
+**Action:** When creating custom button groups that function as mutually exclusive selectors, always use `role="group"` and `aria-label` on the container, and indicate the selected state using `aria-pressed` on the individual buttons. Also, always add `type="button"` and explicit focus states.

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -208,10 +208,12 @@ export default function SettingsView() {
                         </div>
                     </div>
 
-                    <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                    <div className="grid grid-cols-1 md:grid-cols-3 gap-4" role="group" aria-label="Productivity Style">
                         <button
+                            type="button"
+                            aria-pressed={style === 'student'}
                             onClick={() => setStyle('student')}
-                            className={`relative p-4 rounded-xl border-2 text-left transition-all ${
+                            className={`relative p-4 rounded-xl border-2 text-left transition-all focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none ${
                                 style === 'student' 
                                     ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/20' 
                                     : 'border-gray-200 dark:border-neutral-800 hover:border-gray-300 dark:hover:border-neutral-700'
@@ -223,8 +225,10 @@ export default function SettingsView() {
                         </button>
 
                         <button
+                            type="button"
+                            aria-pressed={style === 'professional'}
                             onClick={() => setStyle('professional')}
-                            className={`relative p-4 rounded-xl border-2 text-left transition-all ${
+                            className={`relative p-4 rounded-xl border-2 text-left transition-all focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none ${
                                 style === 'professional' 
                                     ? 'border-indigo-500 bg-indigo-50 dark:bg-indigo-900/20' 
                                     : 'border-gray-200 dark:border-neutral-800 hover:border-gray-300 dark:hover:border-neutral-700'
@@ -236,8 +240,10 @@ export default function SettingsView() {
                         </button>
 
                         <button
+                            type="button"
+                            aria-pressed={style === 'creator'}
                             onClick={() => setStyle('creator')}
-                            className={`relative p-4 rounded-xl border-2 text-left transition-all ${
+                            className={`relative p-4 rounded-xl border-2 text-left transition-all focus-visible:ring-2 focus-visible:ring-purple-500 focus-visible:outline-none ${
                                 style === 'creator' 
                                     ? 'border-purple-500 bg-purple-50 dark:bg-purple-900/20' 
                                     : 'border-gray-200 dark:border-neutral-800 hover:border-gray-300 dark:hover:border-neutral-700'


### PR DESCRIPTION
* 💡 What: Added ARIA roles (`role="group"`), labels (`aria-label`, `aria-pressed`), element types (`type="button"`), and focus ring styles to the "Productivity Style" selector in Settings.
* 🎯 Why: This component was acting as a mutually exclusive segmented control but lacked the semantic structure for screen readers to understand it as a group. It also lacked clear indication of which option was currently selected via assistive technologies, and focus indicators for keyboard navigation.
* 📸 Before/After: Visual changes are limited to a focus ring `focus-visible:ring-2 focus-visible:ring-[color]-500` when tabbing through the options with a keyboard.
* ♿ Accessibility: Improved screen reader announcements by explicitly labeling the container as a "Productivity Style" group and denoting the selected state of the individual buttons via `aria-pressed`. Enhanced keyboard navigation by adding explicit `focus-visible` outlines.

---
*PR created automatically by Jules for task [9474749748961588237](https://jules.google.com/task/9474749748961588237) started by @aryankumar06*