### PR TITLE
🎨 Palette: Improve accessibility of priority selector

### DIFF
--- a/src/components/DittoDashboard.tsx
+++ b/src/components/DittoDashboard.tsx
@@ -96,15 +96,17 @@ export default function DittoDashboard() {
                 </div>
 
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                  <label id="project-priority-label" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                     Priority
                   </label>
-                  <div className="flex gap-2">
+                  <div className="flex gap-2" role="group" aria-labelledby="project-priority-label">
                     {(['low', 'medium', 'high'] as const).map((priority) => (
                       <button
                         key={priority}
+                        type="button"
+                        aria-pressed={newProjectPriority === priority}
                         onClick={() => setNewProjectPriority(priority)}
-                        className={`px-4 py-2 rounded-lg font-medium transition-colors ${
+                        className={`px-4 py-2 rounded-lg font-medium transition-colors focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none ${
                           newProjectPriority === priority
                             ? priority === 'high'
                               ? 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'


### PR DESCRIPTION
💡 What: Added accessibility and keyboard focus support to the custom "Priority" segmented control in DittoDashboard.
🎯 Why: The priority selector functioned like radio buttons but lacked proper semantics, making it difficult for screen readers to understand and for keyboard users to navigate.
📸 Before/After: Visual changes are limited to a blue focus outline when navigating via keyboard. Screen readers now correctly identify the group and the selected state of the options.
♿ Accessibility:
- Added `id="project-priority-label"` to the label and `aria-labelledby` to the button container.
- Added `role="group"` to the button container to group the options semantically.
- Added `type="button"` to prevent unintended form submission.
- Added `aria-pressed` to indicate the active state to screen readers.
- Added `focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none` classes to provide a clear focus indicator for keyboard users without affecting mouse clicks.

---
*PR created automatically by Jules for task [727556832270141515](https://jules.google.com/task/727556832270141515) started by @aryankumar06*