### PR TITLE
🎨 Palette: Accessible Task View Toggle

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,6 @@
 ## 2026-06-08 - Explicit Context for Icon-Only Action Buttons in Lists
 **Learning:** Icon-only action buttons (like Delete) in nested lists or trees without the item's context in the aria-label are ambiguous to screen reader users.
 **Action:** When adding icon-only action buttons to items in lists, always include the specific item's title in the `aria-label` (e.g., `aria-label="Delete task: [Task Title]"`) to provide explicit context.
+## 2024-05-18 - Accessible Mutually Exclusive Selectors
+**Learning:** React component toggle groups built with `div` and custom buttons require `role="group"`, an `aria-label`, and `aria-pressed` states on the inner buttons to convey structure and state to screen readers.
+**Action:** When implementing custom segmented controls or view toggles, consistently apply `role="group"`, label the group container, use `aria-pressed` on the option buttons, add `type="button"`, and ensure visible focus states (`focus-visible`).

--- a/src/components/TaskSection.tsx
+++ b/src/components/TaskSection.tsx
@@ -287,10 +287,16 @@ export default function TaskSection({ selectedDate }: TaskSectionProps) {
           <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">Tasks</h2>
           
           {/* View Mode Toggle - Simplified and explicit */}
-          <div className="flex items-center ml-2 bg-gray-100 dark:bg-neutral-800 rounded-lg p-1 border border-gray-200 dark:border-neutral-700">
+          <div
+            className="flex items-center ml-2 bg-gray-100 dark:bg-neutral-800 rounded-lg p-1 border border-gray-200 dark:border-neutral-700"
+            role="group"
+            aria-label="Task view mode"
+          >
             <button
+              type="button"
+              aria-pressed={viewMode === 'list'}
               onClick={() => setViewMode('list')}
-              className={`px-3 py-1 rounded-md text-xs font-bold transition-all ${
+              className={`px-3 py-1 rounded-md text-xs font-bold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-neutral-800 ${
                 viewMode === 'list' 
                   ? 'bg-blue-600 text-white shadow-sm' 
                   : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
@@ -299,8 +305,10 @@ export default function TaskSection({ selectedDate }: TaskSectionProps) {
               List
             </button>
             <button
+              type="button"
+              aria-pressed={viewMode === 'plan'}
               onClick={() => setViewMode('plan')}
-              className={`px-3 py-1 rounded-md text-xs font-bold transition-all ${
+              className={`px-3 py-1 rounded-md text-xs font-bold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-neutral-800 ${
                 viewMode === 'plan' 
                   ? 'bg-blue-600 text-white shadow-sm' 
                   : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'


### PR DESCRIPTION
**What**: Added proper ARIA attributes (`role="group"`, `aria-label`, `aria-pressed`) and focus ring styles to the view mode toggle buttons (List/Plan) in the `TaskSection` component.
**Why**: The view mode toggle behaves like a mutually exclusive segmented control, but it previously used raw `<button>` elements inside a basic `<div>` without conveying its state or structure to screen readers, and lacked keyboard focus visibility.
**Before/After**: Visually similar, but now features a blue focus ring for keyboard users when navigating between options. Screen readers will now announce "Task view mode group" and "List, button, pressed/unpressed".
**Accessibility**: 
- Added `role="group"` and `aria-label="Task view mode"` to the container.
- Added `aria-pressed` to reflect active state.
- Added explicit `type="button"` to prevent form submission side-effects.
- Added `focus-visible` classes to support visible keyboard navigation.

---
*PR created automatically by Jules for task [11530063175583670990](https://jules.google.com/task/11530063175583670990) started by @aryankumar06*