### PR TITLE
🎨 Palette: Dashboard Form Accessibility & Focus States

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,6 @@
 ## 2026-06-08 - Explicit Context for Icon-Only Action Buttons in Lists
 **Learning:** Icon-only action buttons (like Delete) in nested lists or trees without the item's context in the aria-label are ambiguous to screen reader users.
 **Action:** When adding icon-only action buttons to items in lists, always include the specific item's title in the `aria-label` (e.g., `aria-label="Delete task: [Task Title]"`) to provide explicit context.
+## 2024-10-27 - Custom Button Group Semantics
+**Learning:** Custom toggle button groups (like priority selectors) without proper ARIA grouping are read as disconnected buttons by screen readers.
+**Action:** When creating custom button groups that function as mutually exclusive selectors, use `role="group"` and `aria-label` or `aria-labelledby` on the container, and indicate the selected state using `aria-pressed` on the individual buttons.

--- a/src/components/DittoDashboard.tsx
+++ b/src/components/DittoDashboard.tsx
@@ -44,6 +44,8 @@ export default function DittoDashboard() {
       <div className="mb-6 flex items-center justify-end">
         <button
           onClick={() => setShowAddForm(!showAddForm)}
+          aria-expanded={showAddForm}
+          aria-controls="add-project-form"
           className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors font-medium"
         >
           <Plus className="w-4 h-4" />
@@ -55,6 +57,7 @@ export default function DittoDashboard() {
       <AnimatePresence>
         {showAddForm && (
           <motion.div
+            id="add-project-form"
             initial={{ opacity: 0, height: 0 }}
             animate={{ opacity: 1, height: 'auto' }}
             exit={{ opacity: 0, height: 0 }}
@@ -96,15 +99,17 @@ export default function DittoDashboard() {
                 </div>
 
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                  <label id="priority-label" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                     Priority
                   </label>
-                  <div className="flex gap-2">
+                  <div className="flex gap-2" role="group" aria-labelledby="priority-label">
                     {(['low', 'medium', 'high'] as const).map((priority) => (
                       <button
                         key={priority}
+                        type="button"
+                        aria-pressed={newProjectPriority === priority}
                         onClick={() => setNewProjectPriority(priority)}
-                        className={`px-4 py-2 rounded-lg font-medium transition-colors ${
+                        className={`px-4 py-2 rounded-lg font-medium transition-colors focus-visible:ring-2 focus-visible:ring-blue-500 outline-none ${
                           newProjectPriority === priority
                             ? priority === 'high'
                               ? 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
@@ -122,15 +127,17 @@ export default function DittoDashboard() {
 
                 <div className="flex gap-3 pt-2">
                   <button
+                    type="button"
                     onClick={handleAddProject}
                     disabled={!newProjectTitle.trim()}
-                    className="px-6 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed text-white rounded-lg transition-colors font-medium"
+                    className="px-6 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed text-white rounded-lg transition-colors font-medium focus-visible:ring-2 focus-visible:ring-blue-500 outline-none"
                   >
                     Create Project
                   </button>
                   <button
+                    type="button"
                     onClick={() => setShowAddForm(false)}
-                    className="px-6 py-2 bg-gray-200 hover:bg-gray-300 dark:bg-neutral-700 dark:hover:bg-neutral-600 text-gray-700 dark:text-gray-300 rounded-lg transition-colors font-medium"
+                    className="px-6 py-2 bg-gray-200 hover:bg-gray-300 dark:bg-neutral-700 dark:hover:bg-neutral-600 text-gray-700 dark:text-gray-300 rounded-lg transition-colors font-medium focus-visible:ring-2 focus-visible:ring-blue-500 outline-none"
                   >
                     Cancel
                   </button>


### PR DESCRIPTION
**💡 What:**
Added proper ARIA attributes to the "Add Project" disclosure widget and the Priority selector button group. Also added explicit `type="button"` attributes to interactive elements and clear `focus-visible` styles for keyboard navigation in the DittoDashboard.

**🎯 Why:**
The "Add Project" toggle was missing disclosure semantics, and the Priority buttons were read as disconnected, generic buttons without context or state. Adding keyboard focus states ensures power users and accessibility users can navigate the form smoothly.

**📸 Before/After:**
*Invisible DOM changes / Focus state visual additions only.*

**♿ Accessibility:**
- Added `aria-expanded` and `aria-controls` to link the toggle button to the form.
- Applied `role="group"`, `aria-labelledby`, and `aria-pressed` to the Priority selector to act as a proper mutually exclusive group.
- Added `focus-visible` rings to "Create Project" and "Cancel" buttons.
- Ensured interactive elements don't trigger unwanted native form submissions with `type="button"`.

---
*PR created automatically by Jules for task [9912612398527654102](https://jules.google.com/task/9912612398527654102) started by @aryankumar06*