### PR TITLE
🎨 Palette: Add accessibility attributes to task view mode toggle

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,6 @@
 ## 2026-06-08 - Explicit Context for Icon-Only Action Buttons in Lists
 **Learning:** Icon-only action buttons (like Delete) in nested lists or trees without the item's context in the aria-label are ambiguous to screen reader users.
 **Action:** When adding icon-only action buttons to items in lists, always include the specific item's title in the `aria-label` (e.g., `aria-label="Delete task: [Task Title]"`) to provide explicit context.
+## 2024-05-18 - Task View Mode Toggles Lack Accessibility Context
+**Learning:** Custom button groups that function as mutually exclusive selectors (like a "List" vs "Plan" view mode toggle) need specific ARIA roles (`role="group"`) and states (`aria-pressed`) to be understood correctly by screen readers. Furthermore, interactive buttons should use `type="button"` to avoid unintended native form submissions when used nearby or inside forms, and require explicit focus states (`focus-visible`) for keyboard navigability.
+**Action:** When implementing custom toggle button groups, use `role="group"` on the container with an `aria-label`, set `type="button"` and `aria-pressed={isActive}` on individual buttons, and utilize `focus-visible:ring-2` (or equivalent) for keyboard focus indicators.

--- a/src/components/TaskSection.tsx
+++ b/src/components/TaskSection.tsx
@@ -287,10 +287,16 @@ export default function TaskSection({ selectedDate }: TaskSectionProps) {
           <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">Tasks</h2>
           
           {/* View Mode Toggle - Simplified and explicit */}
-          <div className="flex items-center ml-2 bg-gray-100 dark:bg-neutral-800 rounded-lg p-1 border border-gray-200 dark:border-neutral-700">
+          <div
+            role="group"
+            aria-label="Task view mode"
+            className="flex items-center ml-2 bg-gray-100 dark:bg-neutral-800 rounded-lg p-1 border border-gray-200 dark:border-neutral-700"
+          >
             <button
+              type="button"
               onClick={() => setViewMode('list')}
-              className={`px-3 py-1 rounded-md text-xs font-bold transition-all ${
+              aria-pressed={viewMode === 'list'}
+              className={`px-3 py-1 rounded-md text-xs font-bold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
                 viewMode === 'list' 
                   ? 'bg-blue-600 text-white shadow-sm' 
                   : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
@@ -299,8 +305,10 @@ export default function TaskSection({ selectedDate }: TaskSectionProps) {
               List
             </button>
             <button
+              type="button"
               onClick={() => setViewMode('plan')}
-              className={`px-3 py-1 rounded-md text-xs font-bold transition-all ${
+              aria-pressed={viewMode === 'plan'}
+              className={`px-3 py-1 rounded-md text-xs font-bold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
                 viewMode === 'plan' 
                   ? 'bg-blue-600 text-white shadow-sm' 
                   : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'


### PR DESCRIPTION
**💡 What:** Added explicit accessibility attributes to the Task section's view mode toggle (List vs Plan).
**🎯 Why:** Custom button groups that act as mutually exclusive toggles are ambiguous to screen readers without specific context. Additionally, adding `type="button"` prevents unintended form submissions, and `focus-visible` classes improve keyboard navigability.
**📸 Before/After:** No visual layout changes. Keyboard focus states now show a visible blue ring outline when navigated via the Tab key.
**♿ Accessibility:**
- Added `role="group"` and `aria-label="Task view mode"` to the toggle container.
- Added `type="button"` to both buttons to prevent accidental form submission behavior.
- Added `aria-pressed={true/false}` states to both buttons to communicate the currently active view mode to assistive technologies.
- Added `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500` utility classes for clear keyboard focus indicators.

---
*PR created automatically by Jules for task [10690945149527083755](https://jules.google.com/task/10690945149527083755) started by @aryankumar06*