### PR TITLE
🎨 Palette: Improve accessibility of project priority buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,6 @@
 ## 2026-06-08 - Explicit Context for Icon-Only Action Buttons in Lists
 **Learning:** Icon-only action buttons (like Delete) in nested lists or trees without the item's context in the aria-label are ambiguous to screen reader users.
 **Action:** When adding icon-only action buttons to items in lists, always include the specific item's title in the `aria-label` (e.g., `aria-label="Delete task: [Task Title]"`) to provide explicit context.
+## 2026-08-18 - Custom Button Groups Need Explicit A11y
+**Learning:** React elements acting as mutually exclusive selectors (like a list of buttons for selecting 'Priority') need explicit ARIA grouping (`role="group"`), an `aria-label`, `aria-pressed` on individual buttons to indicate state, and clear focus styles for keyboard users, as standard HTML buttons don't implicitly convey this relationship.
+**Action:** Always wrap custom button groups in a `role="group"`, add `aria-pressed` bindings, explicitly add `type="button"` to prevent implicit submits, and ensure `focus-visible` classes exist.

--- a/src/components/DittoDashboard.tsx
+++ b/src/components/DittoDashboard.tsx
@@ -99,12 +99,14 @@ export default function DittoDashboard() {
                   <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                     Priority
                   </label>
-                  <div className="flex gap-2">
+                  <div className="flex gap-2" role="group" aria-label="Project Priority">
                     {(['low', 'medium', 'high'] as const).map((priority) => (
                       <button
                         key={priority}
+                        type="button"
+                        aria-pressed={newProjectPriority === priority}
                         onClick={() => setNewProjectPriority(priority)}
-                        className={`px-4 py-2 rounded-lg font-medium transition-colors ${
+                        className={`px-4 py-2 rounded-lg font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
                           newProjectPriority === priority
                             ? priority === 'high'
                               ? 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'


### PR DESCRIPTION
**💡 What:** Added proper ARIA roles, labels, and pressed states to the Priority selection button group in the `DittoDashboard` add project form. Also ensured keyboard focus is visible and added `type="button"` to prevent accidental form submissions.
**🎯 Why:** Custom button groups that act as mutually exclusive selectors don't implicitly convey their relationship or state to screen readers. These changes make the priority selector fully accessible and keyboard-navigable.
**📸 Before/After:** Screen readers previously just read "low", "medium", "high" without context of them being a group or which one was selected. Now they announce the group "Project Priority" and whether each button is pressed. Keyboard navigation now clearly shows which button has focus via a blue ring.
**♿ Accessibility:**
- Added `role="group"` and `aria-label="Project Priority"` to the container.
- Added `aria-pressed` to individual buttons to indicate active state.
- Added `focus-visible:ring-2 focus-visible:ring-blue-500` for clear keyboard focus indicators.
- Added `type="button"` to ensure safe usage inside forms.

---
*PR created automatically by Jules for task [3720106528896410318](https://jules.google.com/task/3720106528896410318) started by @aryankumar06*