### PR TITLE
🎨 Palette: [UX improvement] Add ARIA attributes to project form

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,6 @@
 ## 2026-06-08 - Explicit Context for Icon-Only Action Buttons in Lists
 **Learning:** Icon-only action buttons (like Delete) in nested lists or trees without the item's context in the aria-label are ambiguous to screen reader users.
 **Action:** When adding icon-only action buttons to items in lists, always include the specific item's title in the `aria-label` (e.g., `aria-label="Delete task: [Task Title]"`) to provide explicit context.
+## 2024-05-16 - ARIA State for Mutually Exclusive Buttons and Collapsible Forms
+**Learning:** When using custom button groups for mutually exclusive options (like priority levels), screen readers need explicitly defined roles (`role="group"`) and states (`aria-pressed`) to understand the relationship and active selection. Similarly, buttons that toggle form visibility need `aria-expanded` to communicate their collapsible state.
+**Action:** Always wrap custom radio-like button groups in `role="group"` with an `aria-label`, use `aria-pressed` on the individual buttons to indicate selection, and ensure toggle buttons use `aria-expanded`.

--- a/src/components/DittoDashboard.tsx
+++ b/src/components/DittoDashboard.tsx
@@ -44,6 +44,7 @@ export default function DittoDashboard() {
       <div className="mb-6 flex items-center justify-end">
         <button
           onClick={() => setShowAddForm(!showAddForm)}
+          aria-expanded={showAddForm}
           className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors font-medium"
         >
           <Plus className="w-4 h-4" />
@@ -99,10 +100,12 @@ export default function DittoDashboard() {
                   <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                     Priority
                   </label>
-                  <div className="flex gap-2">
+                  <div role="group" aria-label="Project Priority" className="flex gap-2">
                     {(['low', 'medium', 'high'] as const).map((priority) => (
                       <button
                         key={priority}
+                        type="button"
+                        aria-pressed={newProjectPriority === priority}
                         onClick={() => setNewProjectPriority(priority)}
                         className={`px-4 py-2 rounded-lg font-medium transition-colors ${
                           newProjectPriority === priority


### PR DESCRIPTION
* 💡 What: Added ARIA attributes to the "Add Project" button and Priority toggle group in the `DittoDashboard` component.
* 🎯 Why: To improve screen reader accessibility by properly conveying the state of the collapsible form and the relationships/state of the mutually exclusive priority buttons.
* 📸 Before/After: Visuals are unchanged (structural HTML attributes only).
* ♿ Accessibility: Added `aria-expanded` to the toggle button, `role="group"`, `aria-label`, `type="button"`, and `aria-pressed` to the priority buttons.

---
*PR created automatically by Jules for task [5521001661027800584](https://jules.google.com/task/5521001661027800584) started by @aryankumar06*