### PR TITLE
🎨 Palette: Improve accessibility and UX for toggle buttons and forms

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-06-08 - Explicit Context for Icon-Only Action Buttons in Lists
 **Learning:** Icon-only action buttons (like Delete) in nested lists or trees without the item's context in the aria-label are ambiguous to screen reader users.
 **Action:** When adding icon-only action buttons to items in lists, always include the specific item's title in the `aria-label` (e.g., `aria-label="Delete task: [Task Title]"`) to provide explicit context.
+
+## 2024-11-20 - Accessible Collapsible Sections and Button Groups
+**Learning:** Collapsible sections toggled by buttons without `aria-expanded` and `aria-controls`, and mutually exclusive button groups without `role="group"` and `aria-pressed`, cause confusion for screen reader users by hiding the relationship between elements and their current states.
+**Action:** When building collapsible sections, always use `aria-expanded` on the trigger button and `aria-controls` pointing to the controlled element's `id`. For mutually exclusive button groups, use `role="group"` on the container and `aria-pressed` on the individual buttons to indicate state.

--- a/src/components/TaskSection.tsx
+++ b/src/components/TaskSection.tsx
@@ -287,10 +287,16 @@ export default function TaskSection({ selectedDate }: TaskSectionProps) {
           <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">Tasks</h2>
           
           {/* View Mode Toggle - Simplified and explicit */}
-          <div className="flex items-center ml-2 bg-gray-100 dark:bg-neutral-800 rounded-lg p-1 border border-gray-200 dark:border-neutral-700">
+          <div
+            className="flex items-center ml-2 bg-gray-100 dark:bg-neutral-800 rounded-lg p-1 border border-gray-200 dark:border-neutral-700"
+            role="group"
+            aria-label="Task view mode"
+          >
             <button
+              type="button"
+              aria-pressed={viewMode === 'list'}
               onClick={() => setViewMode('list')}
-              className={`px-3 py-1 rounded-md text-xs font-bold transition-all ${
+              className={`px-3 py-1 rounded-md text-xs font-bold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
                 viewMode === 'list' 
                   ? 'bg-blue-600 text-white shadow-sm' 
                   : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
@@ -299,8 +305,10 @@ export default function TaskSection({ selectedDate }: TaskSectionProps) {
               List
             </button>
             <button
+              type="button"
+              aria-pressed={viewMode === 'plan'}
               onClick={() => setViewMode('plan')}
-              className={`px-3 py-1 rounded-md text-xs font-bold transition-all ${
+              className={`px-3 py-1 rounded-md text-xs font-bold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
                 viewMode === 'plan' 
                   ? 'bg-blue-600 text-white shadow-sm' 
                   : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
@@ -312,10 +320,13 @@ export default function TaskSection({ selectedDate }: TaskSectionProps) {
         </div>
 
         <button
+          type="button"
+          aria-expanded={showForm}
+          aria-controls="add-task-form"
           onClick={() => setShowForm(!showForm)}
-          className="flex items-center justify-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors font-medium"
+          className="flex items-center justify-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-800"
         >
-          <Plus className="w-4 h-4" />
+          <Plus className={`w-4 h-4 transition-transform duration-200 ${showForm ? 'rotate-45' : ''}`} />
           {showForm ? 'Close Form' : 'Add Task'}
         </button>
       </div>
@@ -329,6 +340,7 @@ export default function TaskSection({ selectedDate }: TaskSectionProps) {
       <AnimatePresence mode="wait">
         {showForm && (
           <motion.form 
+            id="add-task-form"
             onSubmit={handleSubmit} 
             className="mb-6 p-4 bg-gray-50 dark:bg-neutral-900/30 rounded-lg space-y-4"
             initial={{ opacity: 0, height: 0 }}
@@ -638,9 +650,12 @@ function TaskItem({
               </span>
             )}
             <button 
+                type="button"
+                aria-expanded={showComments}
+                aria-controls={`comments-${task.id}`}
                 onClick={() => setShowComments(!showComments)}
-                className="text-xs text-gray-500 hover:text-blue-500 flex items-center gap-1 transition-colors"
-                title="View Comments"
+                className="text-xs text-gray-500 hover:text-blue-500 flex items-center gap-1 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded px-1"
+                title={showComments ? "Hide Comments" : "View Comments"}
             >
                 <MessageSquare className="w-3 h-3" />
                 {commentCount > 0 ? `${commentCount} comments` : 'Comment'}
@@ -651,6 +666,7 @@ function TaskItem({
           <AnimatePresence>
             {showComments && (
               <motion.div 
+                id={`comments-${task.id}`}
                 className="mt-4 pl-4 border-l-2 border-gray-100 dark:border-neutral-700"
                 initial={{ opacity: 0, height: 0 }}
                 animate={{ opacity: 1, height: 'auto' }}


### PR DESCRIPTION
**💡 What:** 
Added critical accessibility attributes (`aria-expanded`, `aria-controls`, `aria-pressed`, `role="group"`) to interactive buttons in the Task Section. Added standard `type="button"` attributes. Added visible focus rings for keyboard navigation. Added a delightful 45-degree rotation animation to the "Add Task" Plus icon when the form opens, transforming it into a "Close" (X) icon.

**🎯 Why:** 
Screen reader users previously had no way to tell if the "Add Task" or "Comments" sections were open or closed, as the buttons lacked relationship mapping (`aria-controls`) and state information (`aria-expanded`). The view mode toggle buttons (List/Plan) acted as a mutually exclusive radio group but lacked semantic meaning (`role="group"` and `aria-pressed`). Keyboard users lacked clear visual feedback when tabbing through these elements.

**📸 Before/After:** 
(Visual changes are limited to a small rotation animation on the Plus icon and standard Tailwind blue focus rings when navigating via keyboard).

**♿ Accessibility:** 
- `role="group"` and `aria-label` added to the View Mode toggle container.
- `aria-pressed` added to the individual List/Plan toggle buttons.
- `aria-expanded` and `aria-controls` added to the "Add Task" and "Comments" buttons.
- Corresponding `id` tags mapped to the target motion containers for screen readers.
- `focus-visible:ring-2 focus-visible:ring-blue-500` outline styles applied to interactive buttons for robust keyboard navigation support.
- `type="button"` specified to prevent accidental default form submissions.

---
*PR created automatically by Jules for task [16249214333273302801](https://jules.google.com/task/16249214333273302801) started by @aryankumar06*