### PR TITLE
🎨 Palette: Add ARIA roles and pressed states to user type buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,6 @@
 ## 2026-06-08 - Explicit Context for Icon-Only Action Buttons in Lists
 **Learning:** Icon-only action buttons (like Delete) in nested lists or trees without the item's context in the aria-label are ambiguous to screen reader users.
 **Action:** When adding icon-only action buttons to items in lists, always include the specific item's title in the `aria-label` (e.g., `aria-label="Delete task: [Task Title]"`) to provide explicit context.
+## 2024-05-18 - ARIA attributes for custom button groups
+**Learning:** Custom button groups that function as mutually exclusive selectors need specific ARIA attributes for screen readers to understand their grouping and selection state.
+**Action:** Use role="group" and aria-label on the group container, and indicate the selected state using aria-pressed on individual buttons.

--- a/src/components/Auth.tsx
+++ b/src/components/Auth.tsx
@@ -527,9 +527,10 @@ export default function Auth() {
                 {isSignUp && (
                   <div className="space-y-2">
                      <p className="text-xs text-gray-500">I am a...</p>
-                     <div className="grid grid-cols-3 gap-2">
+                     <div className="grid grid-cols-3 gap-2" role="group" aria-label="Select user type">
                         <button
                           type="button"
+                          aria-pressed={userType === 'student'}
                           onClick={() => setUserType('student')}
                           className={`p-3 border rounded-lg text-xs font-medium transition-all ${
                             userType === 'student'
@@ -541,6 +542,7 @@ export default function Auth() {
                         </button>
                         <button
                           type="button"
+                          aria-pressed={userType === 'professional'}
                           onClick={() => setUserType('professional')}
                           className={`p-3 border rounded-lg text-xs font-medium transition-all ${
                             userType === 'professional'
@@ -552,6 +554,7 @@ export default function Auth() {
                         </button>
                         <button
                           type="button"
+                          aria-pressed={userType === 'creator'}
                           onClick={() => setUserType('creator')}
                           className={`p-3 border rounded-lg text-xs font-medium transition-all ${
                             userType === 'creator'


### PR DESCRIPTION
**What:** Added ARIA roles and pressed states to the user type selection buttons in the Auth component.

**Why:** Screen readers need to know that these buttons are grouped together and which one is currently selected. Without these attributes, the selection state is only conveyed visually.

**Before/After:**
- Before: The buttons had visual styles indicating selection, but no semantic markup for grouping or state.
- After: Added `role="group"` and `aria-label="Select user type"` to the container, and `aria-pressed` to each button.

**Accessibility:** Improves screen reader compatibility by explicitly defining the custom button group and communicating the currently selected user type.

---
*PR created automatically by Jules for task [9348056118363153729](https://jules.google.com/task/9348056118363153729) started by @aryankumar06*