### PR TITLE
🎨 Palette: Add accessibility attributes to task view mode toggle

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,6 @@
 ## 2026-06-08 - Explicit Context for Icon-Only Action Buttons in Lists
 **Learning:** Icon-only action buttons (like Delete) in nested lists or trees without the item's context in the aria-label are ambiguous to screen reader users.
 **Action:** When adding icon-only action buttons to items in lists, always include the specific item's title in the `aria-label` (e.g., `aria-label="Delete task: [Task Title]"`) to provide explicit context.
+## 2024-05-30 - View Mode Toggle Button Group Accessibility
+**Learning:** When implementing custom button groups for toggle selectors (like List vs Plan view), screen readers need structural grouping context and state indication, not just visual styling. While role="radio" can be used within a radiogroup, a simpler and robust alternative for dual-toggle buttons without complex arrow key navigation handlers is standard buttons with aria-pressed within a role="group" container.
+**Action:** Always add role="group" with an aria-label to the container of mutually exclusive view toggles, and use aria-pressed={boolean} on the individual standard buttons instead of complex radio roles unless fully implementing keyboard arrow navigation.

--- a/src/components/TaskSection.tsx
+++ b/src/components/TaskSection.tsx
@@ -287,10 +287,16 @@ export default function TaskSection({ selectedDate }: TaskSectionProps) {
           <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">Tasks</h2>
           
           {/* View Mode Toggle - Simplified and explicit */}
-          <div className="flex items-center ml-2 bg-gray-100 dark:bg-neutral-800 rounded-lg p-1 border border-gray-200 dark:border-neutral-700">
+          <div
+            className="flex items-center ml-2 bg-gray-100 dark:bg-neutral-800 rounded-lg p-1 border border-gray-200 dark:border-neutral-700"
+            role="group"
+            aria-label="Task view mode"
+          >
             <button
+              type="button"
+              aria-pressed={viewMode === 'list'}
               onClick={() => setViewMode('list')}
-              className={`px-3 py-1 rounded-md text-xs font-bold transition-all ${
+              className={`px-3 py-1 rounded-md text-xs font-bold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
                 viewMode === 'list' 
                   ? 'bg-blue-600 text-white shadow-sm' 
                   : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
@@ -299,8 +305,10 @@ export default function TaskSection({ selectedDate }: TaskSectionProps) {
               List
             </button>
             <button
+              type="button"
+              aria-pressed={viewMode === 'plan'}
               onClick={() => setViewMode('plan')}
-              className={`px-3 py-1 rounded-md text-xs font-bold transition-all ${
+              className={`px-3 py-1 rounded-md text-xs font-bold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
                 viewMode === 'plan' 
                   ? 'bg-blue-600 text-white shadow-sm' 
                   : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'


### PR DESCRIPTION
💡 **What:** Added structural accessibility semantics and explicit keyboard focus states to the "List / Plan" view mode toggle buttons in the `TaskSection`.

🎯 **Why:** The previous implementation relied purely on visual styling (color changes) to indicate the active state, which is invisible to screen readers. It also lacked a clear visual indicator when navigating via keyboard (tabbing). 

📸 **Before/After:**
*Before:* Toggle buttons were standard divs/buttons with no structural grouping, no active state announcements for screen readers, and no focus outline when tabbed to.
*After:* The container acts as an explicit group (`role="group"`). The buttons announce their selected state (`aria-pressed`), and they feature a clear blue focus ring when navigated to using a keyboard.

♿ **Accessibility:**
- Added `role="group"` and `aria-label="Task view mode"` to the container.
- Added `aria-pressed` to individual buttons to announce the current view state.
- Added `type="button"` to avoid unintended native behaviors.
- Added `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500` for clear keyboard navigation.

---
*PR created automatically by Jules for task [825524728946866979](https://jules.google.com/task/825524728946866979) started by @aryankumar06*