### PR TITLE
🎨 Palette: Improve Add Project Form Accessibility

### DIFF
--- a/src/components/DittoDashboard.tsx
+++ b/src/components/DittoDashboard.tsx
@@ -44,7 +44,9 @@ export default function DittoDashboard() {
       <div className="mb-6 flex items-center justify-end">
         <button
           onClick={() => setShowAddForm(!showAddForm)}
-          className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors font-medium"
+          aria-expanded={showAddForm}
+          aria-controls="add-project-form"
+          className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-800"
         >
           <Plus className="w-4 h-4" />
           {showAddForm ? 'Cancel' : 'Add Project'}
@@ -55,6 +57,7 @@ export default function DittoDashboard() {
       <AnimatePresence>
         {showAddForm && (
           <motion.div
+            id="add-project-form"
             initial={{ opacity: 0, height: 0 }}
             animate={{ opacity: 1, height: 'auto' }}
             exit={{ opacity: 0, height: 0 }}
@@ -63,10 +66,11 @@ export default function DittoDashboard() {
             <div className="bg-white dark:bg-neutral-800 rounded-xl shadow-sm border border-gray-200 dark:border-neutral-700 p-6">
               <div className="space-y-4">
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                  <label htmlFor="project-title" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                     Project Title *
                   </label>
                   <input
+                    id="project-title"
                     type="text"
                     value={newProjectTitle}
                     onChange={(e) => setNewProjectTitle(e.target.value)}
@@ -83,10 +87,11 @@ export default function DittoDashboard() {
                 </div>
 
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                  <label htmlFor="project-description" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                     Description
                   </label>
                   <textarea
+                    id="project-description"
                     value={newProjectDescription}
                     onChange={(e) => setNewProjectDescription(e.target.value)}
                     placeholder="Enter project description..."
@@ -96,15 +101,17 @@ export default function DittoDashboard() {
                 </div>
 
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                  <label id="priority-label" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                     Priority
                   </label>
-                  <div className="flex gap-2">
+                  <div role="group" aria-labelledby="priority-label" className="flex gap-2">
                     {(['low', 'medium', 'high'] as const).map((priority) => (
                       <button
                         key={priority}
+                        type="button"
+                        aria-pressed={newProjectPriority === priority}
                         onClick={() => setNewProjectPriority(priority)}
-                        className={`px-4 py-2 rounded-lg font-medium transition-colors ${
+                        className={`px-4 py-2 rounded-lg font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-800 ${
                           newProjectPriority === priority
                             ? priority === 'high'
                               ? 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
@@ -122,15 +129,17 @@ export default function DittoDashboard() {
 
                 <div className="flex gap-3 pt-2">
                   <button
+                    type="button"
                     onClick={handleAddProject}
                     disabled={!newProjectTitle.trim()}
-                    className="px-6 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed text-white rounded-lg transition-colors font-medium"
+                    className="px-6 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed text-white rounded-lg transition-colors font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-800"
                   >
                     Create Project
                   </button>
                   <button
+                    type="button"
                     onClick={() => setShowAddForm(false)}
-                    className="px-6 py-2 bg-gray-200 hover:bg-gray-300 dark:bg-neutral-700 dark:hover:bg-neutral-600 text-gray-700 dark:text-gray-300 rounded-lg transition-colors font-medium"
+                    className="px-6 py-2 bg-gray-200 hover:bg-gray-300 dark:bg-neutral-700 dark:hover:bg-neutral-600 text-gray-700 dark:text-gray-300 rounded-lg transition-colors font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-800"
                   >
                     Cancel
                   </button>


### PR DESCRIPTION
## 💡 What
Added semantic HTML associations and ARIA attributes to the "Add Project" form in the `DittoDashboard` component. This includes linking labels to inputs, configuring the priority selection as an accessible button group, providing form state controls to the main trigger button, and enhancing keyboard focus rings on all interactive elements.

## 🎯 Why
To ensure the Add Project form is fully accessible and navigable via keyboard and screen readers. The priority selector specifically lacked context as a cohesive group, and focus states were not distinct enough for keyboard users.

## 📸 Before/After
No visual changes to default appearance (attribute and focus-state only).

## ♿ Accessibility
- Added `aria-expanded` and `aria-controls` to the form toggle button.
- Associated "Project Title" and "Description" labels with their fields using `htmlFor`/`id`.
- Added `role="group"` and `aria-labelledby` to the Priority button group.
- Added `type="button"` and `aria-pressed` to individual priority buttons to communicate their state and prevent unintended form submissions.
- Added explicit `focus-visible` ring utility classes to buttons for better keyboard navigation visibility.

---
*PR created automatically by Jules for task [14629654485332350892](https://jules.google.com/task/14629654485332350892) started by @aryankumar06*