### PR TITLE
🎨 Palette: Improve accessibility of Task view controls and add task button

### DIFF
--- a/src/components/TaskSection.tsx
+++ b/src/components/TaskSection.tsx
@@ -287,10 +287,12 @@ export default function TaskSection({ selectedDate }: TaskSectionProps) {
           <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">Tasks</h2>
           
           {/* View Mode Toggle - Simplified and explicit */}
-          <div className="flex items-center ml-2 bg-gray-100 dark:bg-neutral-800 rounded-lg p-1 border border-gray-200 dark:border-neutral-700">
+          <div className="flex items-center ml-2 bg-gray-100 dark:bg-neutral-800 rounded-lg p-1 border border-gray-200 dark:border-neutral-700" role="group" aria-label="Task View Mode">
             <button
+              type="button"
               onClick={() => setViewMode('list')}
-              className={`px-3 py-1 rounded-md text-xs font-bold transition-all ${
+              aria-pressed={viewMode === 'list'}
+              className={`px-3 py-1 rounded-md text-xs font-bold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
                 viewMode === 'list' 
                   ? 'bg-blue-600 text-white shadow-sm' 
                   : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
@@ -299,8 +301,10 @@ export default function TaskSection({ selectedDate }: TaskSectionProps) {
               List
             </button>
             <button
+              type="button"
               onClick={() => setViewMode('plan')}
-              className={`px-3 py-1 rounded-md text-xs font-bold transition-all ${
+              aria-pressed={viewMode === 'plan'}
+              className={`px-3 py-1 rounded-md text-xs font-bold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
                 viewMode === 'plan' 
                   ? 'bg-blue-600 text-white shadow-sm' 
                   : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
@@ -312,8 +316,11 @@ export default function TaskSection({ selectedDate }: TaskSectionProps) {
         </div>
 
         <button
+          type="button"
           onClick={() => setShowForm(!showForm)}
-          className="flex items-center justify-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors font-medium"
+          aria-expanded={showForm}
+          aria-controls="add-task-form"
+          className="flex items-center justify-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
         >
           <Plus className="w-4 h-4" />
           {showForm ? 'Close Form' : 'Add Task'}
@@ -329,6 +336,7 @@ export default function TaskSection({ selectedDate }: TaskSectionProps) {
       <AnimatePresence mode="wait">
         {showForm && (
           <motion.form 
+            id="add-task-form"
             onSubmit={handleSubmit} 
             className="mb-6 p-4 bg-gray-50 dark:bg-neutral-900/30 rounded-lg space-y-4"
             initial={{ opacity: 0, height: 0 }}


### PR DESCRIPTION
**What:** 
Added semantic roles, ARIA labels, explicit button types, and keyboard focus indicators to the View Mode toggle and the Add Task button in the `TaskSection` component.

**Why:** 
To significantly improve accessibility for keyboard and screen reader users. The view mode toggle now behaves as a cohesive button group with clearly announced selected states. The Add Task button now explicitly signals that it controls an expandable form region and provides clear visual feedback when focused via keyboard.

**Before/After:**
*(No visual changes to the default state. Focus outlines are now visible when navigating via keyboard.)*

**Accessibility:**
- Added `role="group"` and `aria-label="Task View Mode"` to the view toggle container.
- Added `aria-pressed` states to the 'List' and 'Plan' buttons to indicate the active view.
- Added `aria-expanded` and `aria-controls` to the 'Add Task' button, linking it to the form `id`.
- Ensured all actionable buttons explicitly declare `type="button"` to prevent accidental form submissions.
- Added `focus-visible:ring-2` Tailwind classes for standard keyboard focus indication.

---
*PR created automatically by Jules for task [14087855882761696149](https://jules.google.com/task/14087855882761696149) started by @aryankumar06*