### PR TITLE
🎨 Palette: Add accessibility to Productivity Style selector

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,6 @@
 ## 2026-06-08 - Explicit Context for Icon-Only Action Buttons in Lists
 **Learning:** Icon-only action buttons (like Delete) in nested lists or trees without the item's context in the aria-label are ambiguous to screen reader users.
 **Action:** When adding icon-only action buttons to items in lists, always include the specific item's title in the `aria-label` (e.g., `aria-label="Delete task: [Task Title]"`) to provide explicit context.
+## 2026-08-28 - Accessible Custom Button Groups
+**Learning:** Custom button groups acting as mutually exclusive selectors (like segmented controls) need proper ARIA roles and state management to be usable by screen readers.
+**Action:** Always wrap custom button groups in a container with `role="group"` and an `aria-label`, and ensure individual buttons have `type="button"`, clear `focus-visible` states, and use `aria-pressed` to denote selection state.

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -208,10 +208,12 @@ export default function SettingsView() {
                         </div>
                     </div>
 
-                    <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                    <div className="grid grid-cols-1 md:grid-cols-3 gap-4" role="group" aria-label="Productivity Style">
                         <button
+                            type="button"
+                            aria-pressed={style === 'student'}
                             onClick={() => setStyle('student')}
-                            className={`relative p-4 rounded-xl border-2 text-left transition-all ${
+                            className={`relative p-4 rounded-xl border-2 text-left transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-900 ${
                                 style === 'student' 
                                     ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/20' 
                                     : 'border-gray-200 dark:border-neutral-800 hover:border-gray-300 dark:hover:border-neutral-700'
@@ -223,8 +225,10 @@ export default function SettingsView() {
                         </button>
 
                         <button
+                            type="button"
+                            aria-pressed={style === 'professional'}
                             onClick={() => setStyle('professional')}
-                            className={`relative p-4 rounded-xl border-2 text-left transition-all ${
+                            className={`relative p-4 rounded-xl border-2 text-left transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-900 ${
                                 style === 'professional' 
                                     ? 'border-indigo-500 bg-indigo-50 dark:bg-indigo-900/20' 
                                     : 'border-gray-200 dark:border-neutral-800 hover:border-gray-300 dark:hover:border-neutral-700'
@@ -236,8 +240,10 @@ export default function SettingsView() {
                         </button>
 
                         <button
+                            type="button"
+                            aria-pressed={style === 'creator'}
                             onClick={() => setStyle('creator')}
-                            className={`relative p-4 rounded-xl border-2 text-left transition-all ${
+                            className={`relative p-4 rounded-xl border-2 text-left transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-900 ${
                                 style === 'creator' 
                                     ? 'border-purple-500 bg-purple-50 dark:bg-purple-900/20' 
                                     : 'border-gray-200 dark:border-neutral-800 hover:border-gray-300 dark:hover:border-neutral-700'


### PR DESCRIPTION
**What:**
Added semantic accessibility attributes (`role="group"`, `aria-label`, `type="button"`, `aria-pressed`) and visible keyboard focus states (`focus-visible:ring`) to the Productivity Style button group in `SettingsView`.

**Why:**
The "Productivity Style" selection was using standard HTML `<button>` elements styled as selectable cards, but lacked the necessary grouping context for screen readers and visible focus indicators for keyboard navigation. This change ensures the selector is fully accessible.

**Before/After:**
*(Visual changes are limited to a focus ring when navigating via keyboard.)*

**Accessibility:**
- Added `role="group"` and `aria-label="Productivity Style"` to the container so screen readers announce it as a related group of options.
- Added `type="button"` to prevent accidental form submissions.
- Added `aria-pressed={style === '...'}` so screen readers can announce the selected state.
- Added distinct `focus-visible:ring-2` styles to each button (matching their respective theme colors) to improve visibility for keyboard users.

---
*PR created automatically by Jules for task [15569870382740097970](https://jules.google.com/task/15569870382740097970) started by @aryankumar06*