### PR TITLE
🎨 Palette: [Accessibility] Add ARIA labels and focus states to hierarchical view buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,6 @@
 ## 2026-06-08 - Explicit Context for Icon-Only Action Buttons in Lists
 **Learning:** Icon-only action buttons (like Delete) in nested lists or trees without the item's context in the aria-label are ambiguous to screen reader users.
 **Action:** When adding icon-only action buttons to items in lists, always include the specific item's title in the `aria-label` (e.g., `aria-label="Delete task: [Task Title]"`) to provide explicit context.
+## 2024-08-29 - State and Context for Hierarchical Toggle Buttons
+**Learning:** Expanding/collapsing elements and status toggles in nested lists can be difficult for screen reader and keyboard users if they lack state attributes (like `aria-expanded`), context in labels, or visible focus indicators.
+**Action:** Add `aria-expanded` to disclosure widgets, include item context in `aria-label` for status/expand buttons, and add `focus-visible:ring-2` for clear keyboard navigation.

--- a/src/components/ui/agent-plan.tsx
+++ b/src/components/ui/agent-plan.tsx
@@ -241,8 +241,10 @@ export default function Plan() {
                   {/* Expand/Collapse */}
                   {hasChildren && (
                     <button
+                      aria-expanded={isExpanded}
+                      aria-label={`${isExpanded ? 'Collapse' : 'Expand'} project: ${project.title}`}
                       onClick={() => toggleExpand(project.id)}
-                      className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+                      className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 focus-visible:ring-2 focus-visible:ring-blue-500 rounded-sm"
                     >
                       {isExpanded ? <ChevronDown className="w-5 h-5" /> : <ChevronRight className="w-5 h-5" />}
                     </button>
@@ -250,8 +252,9 @@ export default function Plan() {
 
                   {/* Status Icon - Animated */}
                   <motion.button
+                    aria-label={`Toggle status for project: ${project.title}`}
                     onClick={() => toggleStatus(project.id, project.status)}
-                    className="flex-shrink-0 hover:opacity-80 transition-opacity"
+                    className="flex-shrink-0 hover:opacity-80 transition-opacity focus-visible:ring-2 focus-visible:ring-blue-500 rounded-full"
                   >
                     <AnimatePresence mode="wait">
                       <motion.div
@@ -372,8 +375,10 @@ export default function Plan() {
                               {/* Expand/Collapse */}
                               {hasSubtasks && (
                                 <button
+                                  aria-expanded={isTaskExpanded}
+                                  aria-label={`${isTaskExpanded ? 'Collapse' : 'Expand'} task: ${task.title}`}
                                   onClick={() => toggleExpand(task.id)}
-                                  className="text-gray-400 hover:text-gray-600"
+                                  className="text-gray-400 hover:text-gray-600 focus-visible:ring-2 focus-visible:ring-blue-500 rounded-sm"
                                 >
                                   {isTaskExpanded ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
                                 </button>
@@ -381,8 +386,9 @@ export default function Plan() {
 
                               {/* Status Icon - Animated */}
                               <motion.button
+                                aria-label={`Toggle status for task: ${task.title}`}
                                 onClick={() => toggleStatus(task.id, task.status)}
-                                className="flex-shrink-0 hover:opacity-80 transition-opacity"
+                                className="flex-shrink-0 hover:opacity-80 transition-opacity focus-visible:ring-2 focus-visible:ring-blue-500 rounded-full"
                               >
                                 <AnimatePresence mode="wait">
                                   <motion.div
@@ -484,8 +490,9 @@ export default function Plan() {
                                   {task.subtasks.map((subtask) => (
                                     <div key={subtask.id} className="flex items-center gap-3 py-1">
                                       <motion.button
+                                        aria-label={`Toggle status for subtask: ${subtask.title}`}
                                         onClick={() => toggleStatus(subtask.id, subtask.status)}
-                                        className="flex-shrink-0 hover:opacity-80 transition-opacity"
+                                        className="flex-shrink-0 hover:opacity-80 transition-opacity focus-visible:ring-2 focus-visible:ring-blue-500 rounded-full"
                                       >
                                         <AnimatePresence mode="wait">
                                           <motion.div


### PR DESCRIPTION
**What**: Added `aria-expanded`, explicit contextual `aria-label`s (e.g., "Expand project: [Title]"), and `focus-visible:ring-2` keyboard focus states to the icon-only buttons (expand/collapse toggles and status checkboxes) in the Agent Plan hierarchical view. Also recorded this learning in `.Jules/palette.md`.

**Why**: Icon-only buttons without `aria-label`s lack necessary context for screen reader users, making it difficult to understand what action they perform on which specific item. A lack of focus rings makes keyboard navigation difficult for users with mobility impairments who rely on visual focus indicators.

**Before/After**: 
*Before*: `<button><ChevronDown/></button>` and `<motion.button>...</motion.button>` (No contextual labels or focus states).
*After*: `<button aria-expanded="true" aria-label="Collapse task: Setup Backend" className="... focus-visible:ring-2 focus-visible:ring-blue-500 rounded-sm">...`

**Accessibility**: 
- Improved screen reader support by providing explicit contextual names for icon-only action buttons.
- Improved screen reader support by communicating the expanded/collapsed state of disclosure widgets.
- Improved keyboard accessibility by providing a clear, visible focus indicator (`focus-visible:ring-2`) when tabbing through the hierarchy.

---
*PR created automatically by Jules for task [6527809500750231764](https://jules.google.com/task/6527809500750231764) started by @aryankumar06*