### PR TITLE
🎨 Palette: Add explicit ARIA attributes to Task Status menu

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,6 @@
 ## 2026-06-08 - Explicit Context for Icon-Only Action Buttons in Lists
 **Learning:** Icon-only action buttons (like Delete) in nested lists or trees without the item's context in the aria-label are ambiguous to screen reader users.
 **Action:** When adding icon-only action buttons to items in lists, always include the specific item's title in the `aria-label` (e.g., `aria-label="Delete task: [Task Title]"`) to provide explicit context.
+## 2024-05-18 - Collapsible Sections and Disclosure Widgets Accessibility
+**Learning:** Collapsible sections or disclosure widgets without the proper ARIA attributes make it hard for screen reader users to understand the state and relationship of the elements.
+**Action:** When building collapsible sections or disclosure widgets (e.g., an expanding form toggled by a button), always use the `aria-expanded` attribute on the trigger button to indicate state, and the `aria-controls` attribute pointing to the controlled element's `id`.

--- a/src/components/WorkspaceView.tsx
+++ b/src/components/WorkspaceView.tsx
@@ -1001,13 +1001,15 @@ function TaskCard({ task, role, isManager, getMemberName, onUpdateStatus, onDele
                         <button
                             onClick={() => setShowStatusMenu(!showStatusMenu)}
                             className="text-xs text-blue-600 hover:text-blue-700 font-medium flex items-center gap-1"
+                            aria-expanded={showStatusMenu}
+                            aria-controls={`status-menu-${task.id}`}
                         >
                             Move to...
                             <ChevronRight className={`w-3 h-3 transition-transform ${showStatusMenu ? 'rotate-90' : ''}`} />
                         </button>
                         
                         {showStatusMenu && (
-                            <div className="absolute left-0 top-6 bg-white dark:bg-neutral-800 border border-gray-200 dark:border-neutral-700 rounded-lg shadow-lg py-1 z-10 min-w-[120px]">
+                            <div id={`status-menu-${task.id}`} className="absolute left-0 top-6 bg-white dark:bg-neutral-800 border border-gray-200 dark:border-neutral-700 rounded-lg shadow-lg py-1 z-10 min-w-[120px]">
                                 {allowedNextStates.map(status => {
                                     const config = getStatusConfig(status);
                                     return (


### PR DESCRIPTION
### 💡 What
Added `aria-expanded` and `aria-controls` to the "Move to..." task status button in the `WorkspaceView` component.

### 🎯 Why
Without these attributes, screen reader users cannot easily determine if the status menu is open or closed, nor can they explicitly trace which element is controlled by the toggle button. This change makes the disclosure widget state and its controlled content explicit.

### 📸 Before/After
*(Visuals remain unchanged, this is an underlying DOM accessibility improvement).*

### ♿ Accessibility
*   Added `aria-expanded` to accurately reflect the open/closed state of the status menu.
*   Added `aria-controls` to link the toggle button directly to the menu container, which was given a corresponding, unique `id`.

---
*PR created automatically by Jules for task [9827726684148868034](https://jules.google.com/task/9827726684148868034) started by @aryankumar06*