### PR TITLE
🎨 Palette: Improve accessibility of Task View toggles and Add Task form

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,10 @@
 ## 2026-06-08 - Explicit Context for Icon-Only Action Buttons in Lists
 **Learning:** Icon-only action buttons (like Delete) in nested lists or trees without the item's context in the aria-label are ambiguous to screen reader users.
 **Action:** When adding icon-only action buttons to items in lists, always include the specific item's title in the `aria-label` (e.g., `aria-label="Delete task: [Task Title]"`) to provide explicit context.
+## 2024-11-20 - Disclosure Widget States
+**Learning:** Collapsible form sections triggered by a button can confuse screen reader users if they do not announce their expanded state and controlled relationship.
+**Action:** When building collapsible sections or disclosure widgets (e.g., an expanding form toggled by a button), always use the `aria-expanded` attribute on the trigger button to indicate state, and the `aria-controls` attribute pointing to the controlled element's `id`.
+
+## 2024-11-20 - Custom Button Groups
+**Learning:** Custom UI toggles (like "List" vs "Plan" view toggles) that function as mutually exclusive selectors lack semantic meaning without appropriate ARIA roles.
+**Action:** For custom button groups functioning as selectors, use `role="group"` and `aria-label` or `aria-labelledby` on the group container, indicate the selected state using `aria-pressed` on the individual buttons, ensure they have `type="button"`, and include explicit `focus-visible` styles for keyboard navigability.

--- a/src/components/TaskSection.tsx
+++ b/src/components/TaskSection.tsx
@@ -287,10 +287,12 @@ export default function TaskSection({ selectedDate }: TaskSectionProps) {
           <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">Tasks</h2>
           
           {/* View Mode Toggle - Simplified and explicit */}
-          <div className="flex items-center ml-2 bg-gray-100 dark:bg-neutral-800 rounded-lg p-1 border border-gray-200 dark:border-neutral-700">
+          <div role="group" aria-label="View mode" className="flex items-center ml-2 bg-gray-100 dark:bg-neutral-800 rounded-lg p-1 border border-gray-200 dark:border-neutral-700">
             <button
+              type="button"
+              aria-pressed={viewMode === 'list'}
               onClick={() => setViewMode('list')}
-              className={`px-3 py-1 rounded-md text-xs font-bold transition-all ${
+              className={`px-3 py-1 rounded-md text-xs font-bold transition-all focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none ${
                 viewMode === 'list' 
                   ? 'bg-blue-600 text-white shadow-sm' 
                   : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
@@ -299,8 +301,10 @@ export default function TaskSection({ selectedDate }: TaskSectionProps) {
               List
             </button>
             <button
+              type="button"
+              aria-pressed={viewMode === 'plan'}
               onClick={() => setViewMode('plan')}
-              className={`px-3 py-1 rounded-md text-xs font-bold transition-all ${
+              className={`px-3 py-1 rounded-md text-xs font-bold transition-all focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none ${
                 viewMode === 'plan' 
                   ? 'bg-blue-600 text-white shadow-sm' 
                   : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
@@ -313,7 +317,9 @@ export default function TaskSection({ selectedDate }: TaskSectionProps) {
 
         <button
           onClick={() => setShowForm(!showForm)}
-          className="flex items-center justify-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors font-medium"
+          aria-expanded={showForm}
+          aria-controls="add-task-form"
+          className="flex items-center justify-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors font-medium focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:outline-none"
         >
           <Plus className="w-4 h-4" />
           {showForm ? 'Close Form' : 'Add Task'}
@@ -329,6 +335,7 @@ export default function TaskSection({ selectedDate }: TaskSectionProps) {
       <AnimatePresence mode="wait">
         {showForm && (
           <motion.form 
+            id="add-task-form"
             onSubmit={handleSubmit} 
             className="mb-6 p-4 bg-gray-50 dark:bg-neutral-900/30 rounded-lg space-y-4"
             initial={{ opacity: 0, height: 0 }}


### PR DESCRIPTION
* 💡 **What**: Added proper ARIA roles, semantic attributes, and keyboard focus styling to the View Mode toggles (List/Plan) and the Add Task disclosure form trigger.
* 🎯 **Why**: To enhance keyboard navigability and explicitly announce the purpose and state of these interactive controls to screen reader users, resolving ambiguity when switching views or toggling the task creation form.
* 📸 **Before/After**: Visually identical, but keyboard navigation now clearly highlights focused items with a blue ring, and screen readers will correctly announce the expanded state of the form and the selected view mode.
* ♿ **Accessibility**: 
  - Added `role="group"` and `aria-label="View mode"` to the view toggle container.
  - Added `aria-pressed` states and explicit `type="button"` to the view toggles.
  - Added `aria-expanded` and `aria-controls` to the "Add Task" button, wiring it to the conditionally rendered form's `id`.
  - Implemented `focus-visible:ring-2 focus-visible:ring-blue-500` across these controls for high-visibility keyboard focus.

---
*PR created automatically by Jules for task [6149127909794350741](https://jules.google.com/task/6149127909794350741) started by @aryankumar06*