### PR TITLE
🎨 Palette: Add accessibility bindings and focus states to task UI

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-06-08 - Explicit Context for Icon-Only Action Buttons in Lists
 **Learning:** Icon-only action buttons (like Delete) in nested lists or trees without the item's context in the aria-label are ambiguous to screen reader users.
 **Action:** When adding icon-only action buttons to items in lists, always include the specific item's title in the `aria-label` (e.g., `aria-label="Delete task: [Task Title]"`) to provide explicit context.
+
+## 2024-10-25 - Interactive Toggle States
+**Learning:** Disclosure widgets (like Add Task/Comments) and custom button groups (View Mode) require explicit `aria-expanded` or `aria-pressed` state bindings to be perceivable by screen readers. Relying only on visual changes hides state from assistive tech.
+**Action:** Always bind `aria-expanded` to boolean visibility states for collapsible panels and `aria-pressed` for custom toggle groups, along with matching `focus-visible` styles.

--- a/src/components/TaskSection.tsx
+++ b/src/components/TaskSection.tsx
@@ -287,10 +287,12 @@ export default function TaskSection({ selectedDate }: TaskSectionProps) {
           <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">Tasks</h2>
           
           {/* View Mode Toggle - Simplified and explicit */}
-          <div className="flex items-center ml-2 bg-gray-100 dark:bg-neutral-800 rounded-lg p-1 border border-gray-200 dark:border-neutral-700">
+          <div role="group" aria-label="Task view mode" className="flex items-center ml-2 bg-gray-100 dark:bg-neutral-800 rounded-lg p-1 border border-gray-200 dark:border-neutral-700">
             <button
+              type="button"
+              aria-pressed={viewMode === 'list'}
               onClick={() => setViewMode('list')}
-              className={`px-3 py-1 rounded-md text-xs font-bold transition-all ${
+              className={`px-3 py-1 rounded-md text-xs font-bold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
                 viewMode === 'list' 
                   ? 'bg-blue-600 text-white shadow-sm' 
                   : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
@@ -299,8 +301,10 @@ export default function TaskSection({ selectedDate }: TaskSectionProps) {
               List
             </button>
             <button
+              type="button"
+              aria-pressed={viewMode === 'plan'}
               onClick={() => setViewMode('plan')}
-              className={`px-3 py-1 rounded-md text-xs font-bold transition-all ${
+              className={`px-3 py-1 rounded-md text-xs font-bold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
                 viewMode === 'plan' 
                   ? 'bg-blue-600 text-white shadow-sm' 
                   : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
@@ -313,7 +317,9 @@ export default function TaskSection({ selectedDate }: TaskSectionProps) {
 
         <button
           onClick={() => setShowForm(!showForm)}
-          className="flex items-center justify-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors font-medium"
+          aria-expanded={showForm}
+          aria-controls="add-task-form"
+          className="flex items-center justify-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
         >
           <Plus className="w-4 h-4" />
           {showForm ? 'Close Form' : 'Add Task'}
@@ -329,6 +335,7 @@ export default function TaskSection({ selectedDate }: TaskSectionProps) {
       <AnimatePresence mode="wait">
         {showForm && (
           <motion.form 
+            id="add-task-form"
             onSubmit={handleSubmit} 
             className="mb-6 p-4 bg-gray-50 dark:bg-neutral-900/30 rounded-lg space-y-4"
             initial={{ opacity: 0, height: 0 }}
@@ -639,7 +646,9 @@ function TaskItem({
             )}
             <button 
                 onClick={() => setShowComments(!showComments)}
-                className="text-xs text-gray-500 hover:text-blue-500 flex items-center gap-1 transition-colors"
+                aria-expanded={showComments}
+                aria-controls={`comments-section-${task.id}`}
+                className="text-xs text-gray-500 hover:text-blue-500 flex items-center gap-1 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
                 title="View Comments"
             >
                 <MessageSquare className="w-3 h-3" />
@@ -651,6 +660,7 @@ function TaskItem({
           <AnimatePresence>
             {showComments && (
               <motion.div 
+                id={`comments-section-${task.id}`}
                 className="mt-4 pl-4 border-l-2 border-gray-100 dark:border-neutral-700"
                 initial={{ opacity: 0, height: 0 }}
                 animate={{ opacity: 1, height: 'auto' }}


### PR DESCRIPTION
### 💡 What
Added proper ARIA state bindings to interactive UI elements in the `TaskSection` component:
- The custom "View Mode" (List/Plan) toggle buttons now use `role="group"` and `aria-pressed` to correctly announce their active state.
- The "Add Task" button and inline "View Comments" buttons now use `aria-expanded` and `aria-controls` to announce the visibility of their respective disclosure panels.
- Added `focus-visible` utility classes to these buttons to provide clear visual feedback during keyboard navigation.

### 🎯 Why
Screen reader users need explicit state announcements for interactive UI elements. Relying solely on visual changes (like button background color or panel visibility) hides the state from assistive technologies. Furthermore, keyboard users require distinct visual indicators to know which element is currently focused.

### 📸 Before/After
*(No persistent visual changes. Enhancements are strictly structural ARIA attributes and focus-state CSS classes).*

### ♿ Accessibility
- Added `role="group"` and `aria-pressed` for custom radio-style toggle buttons.
- Added `aria-expanded` and `aria-controls` for disclosure widgets.
- Added `focus-visible:ring-2 focus-visible:ring-blue-500` to all affected buttons to support keyboard accessibility.

---
*PR created automatically by Jules for task [17306764791206964139](https://jules.google.com/task/17306764791206964139) started by @aryankumar06*