### PR TITLE
🎨 Palette: Add accessible button group for view mode toggle

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-06-08 - Explicit Context for Icon-Only Action Buttons in Lists
 **Learning:** Icon-only action buttons (like Delete) in nested lists or trees without the item's context in the aria-label are ambiguous to screen reader users.
 **Action:** When adding icon-only action buttons to items in lists, always include the specific item's title in the `aria-label` (e.g., `aria-label="Delete task: [Task Title]"`) to provide explicit context.
+
+## 2024-05-18 - Accessible Mutually Exclusive Selectors
+**Learning:** Custom button groups that function as mutually exclusive selectors (like view mode toggles) need explicit roles and states to be understood by screen readers.
+**Action:** Always use `role="group"` with an `aria-label` on the container, and `aria-pressed={condition}` with `type="button"` on the individual buttons. Ensure they have clear `focus-visible` styles.

--- a/src/components/TaskSection.tsx
+++ b/src/components/TaskSection.tsx
@@ -287,10 +287,12 @@ export default function TaskSection({ selectedDate }: TaskSectionProps) {
           <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">Tasks</h2>
           
           {/* View Mode Toggle - Simplified and explicit */}
-          <div className="flex items-center ml-2 bg-gray-100 dark:bg-neutral-800 rounded-lg p-1 border border-gray-200 dark:border-neutral-700">
+          <div role="group" aria-label="View mode" className="flex items-center ml-2 bg-gray-100 dark:bg-neutral-800 rounded-lg p-1 border border-gray-200 dark:border-neutral-700">
             <button
+              type="button"
+              aria-pressed={viewMode === 'list'}
               onClick={() => setViewMode('list')}
-              className={`px-3 py-1 rounded-md text-xs font-bold transition-all ${
+              className={`px-3 py-1 rounded-md text-xs font-bold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
                 viewMode === 'list' 
                   ? 'bg-blue-600 text-white shadow-sm' 
                   : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
@@ -299,8 +301,10 @@ export default function TaskSection({ selectedDate }: TaskSectionProps) {
               List
             </button>
             <button
+              type="button"
+              aria-pressed={viewMode === 'plan'}
               onClick={() => setViewMode('plan')}
-              className={`px-3 py-1 rounded-md text-xs font-bold transition-all ${
+              className={`px-3 py-1 rounded-md text-xs font-bold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
                 viewMode === 'plan' 
                   ? 'bg-blue-600 text-white shadow-sm' 
                   : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'


### PR DESCRIPTION
💡 **What**: Added accessibility attributes (`role="group"`, `aria-label`, `aria-pressed`, `type="button"`) and `focus-visible` styles to the view mode toggle buttons (List/Plan) in the `TaskSection`.

🎯 **Why**: Previously, the view mode toggles were just regular buttons without any grouping context or selected state indication for screen readers. They also lacked clear visual focus indicators for keyboard users. This change makes the custom button group accessible as a mutually exclusive selector.

📸 **Before/After**: Visually unchanged by default, but now displays a clear blue ring (`focus-visible:ring-2 focus-visible:ring-blue-500`) when navigating via keyboard (Tab).

♿ **Accessibility**: 
- Added `role="group"` and `aria-label="View mode"` to the container.
- Added `aria-pressed` to indicate which view mode is currently active to screen readers.
- Added `focus-visible` classes for clear keyboard focus indicators.
- Added `type="button"` to prevent potential accidental form submissions.

---
*PR created automatically by Jules for task [5867164233018881032](https://jules.google.com/task/5867164233018881032) started by @aryankumar06*