### PR TITLE
🎨 Palette: [Accessibility] Improve view mode toggle button group

### DIFF
--- a/src/components/TaskSection.tsx
+++ b/src/components/TaskSection.tsx
@@ -287,10 +287,16 @@ export default function TaskSection({ selectedDate }: TaskSectionProps) {
           <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">Tasks</h2>
           
           {/* View Mode Toggle - Simplified and explicit */}
-          <div className="flex items-center ml-2 bg-gray-100 dark:bg-neutral-800 rounded-lg p-1 border border-gray-200 dark:border-neutral-700">
+          <div
+            className="flex items-center ml-2 bg-gray-100 dark:bg-neutral-800 rounded-lg p-1 border border-gray-200 dark:border-neutral-700"
+            role="group"
+            aria-label="View mode"
+          >
             <button
+              type="button"
+              aria-pressed={viewMode === 'list'}
               onClick={() => setViewMode('list')}
-              className={`px-3 py-1 rounded-md text-xs font-bold transition-all ${
+              className={`px-3 py-1 rounded-md text-xs font-bold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
                 viewMode === 'list' 
                   ? 'bg-blue-600 text-white shadow-sm' 
                   : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
@@ -299,8 +305,10 @@ export default function TaskSection({ selectedDate }: TaskSectionProps) {
               List
             </button>
             <button
+              type="button"
+              aria-pressed={viewMode === 'plan'}
               onClick={() => setViewMode('plan')}
-              className={`px-3 py-1 rounded-md text-xs font-bold transition-all ${
+              className={`px-3 py-1 rounded-md text-xs font-bold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
                 viewMode === 'plan' 
                   ? 'bg-blue-600 text-white shadow-sm' 
                   : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'


### PR DESCRIPTION
### 💡 What
Added proper accessibility attributes (`role="group"`, `aria-label`, `aria-pressed`) and `focus-visible` states to the View Mode toggle ("List" / "Plan") in `TaskSection.tsx`.

### 🎯 Why
The custom button group lacked semantic meaning for screen readers. By adding `role="group"` and `aria-pressed`, screen reader users can now understand that these buttons form a mutually exclusive toggle group and can identify the currently active view. Additionally, adding `focus-visible:ring-2` improves keyboard navigation by providing a clear focus indicator.

### 📸 Before/After
No visual changes to the layout. The focus rings will now appear for keyboard users.

### ♿ Accessibility
- Added `role="group"` to the container.
- Added `aria-label="View mode"` to the container.
- Added `type="button"` to prevent unintended default behaviors.
- Added `aria-pressed={...}` to accurately reflect the active state.
- Added `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500` to both buttons for clear keyboard focus indicators.

---
*PR created automatically by Jules for task [16883444696242370342](https://jules.google.com/task/16883444696242370342) started by @aryankumar06*