### PR TITLE
🎨 Palette: [Accessibility] Add proper ARIA to Productivity Style button group

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-06-08 - Explicit Context for Icon-Only Action Buttons in Lists
 **Learning:** Icon-only action buttons (like Delete) in nested lists or trees without the item's context in the aria-label are ambiguous to screen reader users.
 **Action:** When adding icon-only action buttons to items in lists, always include the specific item's title in the `aria-label` (e.g., `aria-label="Delete task: [Task Title]"`) to provide explicit context.
+
+## 2024-09-06 - Accessible Custom Button Groups
+**Learning:** Custom button groups acting as mutually exclusive selectors without proper roles and ARIA attributes (like `role="group"` and `aria-pressed`) fail to convey their grouped nature and selected state to assistive technologies, reducing keyboard accessibility if `focus-visible` states are missing.
+**Action:** When building custom button groups that function as mutually exclusive selectors, use `role="group"` with an `aria-label` or `aria-labelledby` on the group container, and indicate the selected state using `aria-pressed` on the individual buttons. Also, add `type="button"` and ensure clear `focus-visible` classes for keyboard navigation.

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -208,10 +208,12 @@ export default function SettingsView() {
                         </div>
                     </div>
 
-                    <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                    <div className="grid grid-cols-1 md:grid-cols-3 gap-4" role="group" aria-label="Productivity Style Options">
                         <button
+                            type="button"
+                            aria-pressed={style === 'student'}
                             onClick={() => setStyle('student')}
-                            className={`relative p-4 rounded-xl border-2 text-left transition-all ${
+                            className={`relative p-4 rounded-xl border-2 text-left transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
                                 style === 'student' 
                                     ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/20' 
                                     : 'border-gray-200 dark:border-neutral-800 hover:border-gray-300 dark:hover:border-neutral-700'
@@ -223,8 +225,10 @@ export default function SettingsView() {
                         </button>
 
                         <button
+                            type="button"
+                            aria-pressed={style === 'professional'}
                             onClick={() => setStyle('professional')}
-                            className={`relative p-4 rounded-xl border-2 text-left transition-all ${
+                            className={`relative p-4 rounded-xl border-2 text-left transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 ${
                                 style === 'professional' 
                                     ? 'border-indigo-500 bg-indigo-50 dark:bg-indigo-900/20' 
                                     : 'border-gray-200 dark:border-neutral-800 hover:border-gray-300 dark:hover:border-neutral-700'
@@ -236,8 +240,10 @@ export default function SettingsView() {
                         </button>
 
                         <button
+                            type="button"
+                            aria-pressed={style === 'creator'}
                             onClick={() => setStyle('creator')}
-                            className={`relative p-4 rounded-xl border-2 text-left transition-all ${
+                            className={`relative p-4 rounded-xl border-2 text-left transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 ${
                                 style === 'creator' 
                                     ? 'border-purple-500 bg-purple-50 dark:bg-purple-900/20' 
                                     : 'border-gray-200 dark:border-neutral-800 hover:border-gray-300 dark:hover:border-neutral-700'


### PR DESCRIPTION
💡 **What:** Added proper ARIA attributes (`role="group"`, `aria-label`, `aria-pressed`) and keyboard focus states (`focus-visible`) to the Productivity Style button group in Settings. Also appended an accessibility learning to `.Jules/palette.md`.

🎯 **Why:** Custom button groups that act as mutually exclusive selectors without semantic HTML or ARIA roles fail to convey their grouped nature and selected state to assistive technologies. Furthermore, they need proper keyboard focus states so users navigating via Tab can see which element has focus.

📸 **Before/After:**
*   **Before:** Screen readers read three unassociated buttons with no indication of which one was currently active. Tabbing onto the buttons had inconsistent/no visual focus ring.
*   **After:** Screen readers announce "Productivity Style Options, group", followed by each button and its pressed state. Tabbing through the options clearly shows a focus ring (`focus-visible:ring-2`) matching the brand color of that specific style option (blue, indigo, or purple).

♿ **Accessibility:**
*   Added `role="group"` and `aria-label="Productivity Style Options"` to the container.
*   Added `type="button"` and dynamic `aria-pressed` to the inner buttons.
*   Added `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color]` for clear keyboard navigation states.

---
*PR created automatically by Jules for task [4803245073376012378](https://jules.google.com/task/4803245073376012378) started by @aryankumar06*