### PR TITLE
🎨 Palette: View Mode Toggle Button Group Accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,4 @@
 ## 2026-06-08 - Explicit Context for Icon-Only Action Buttons in Lists
 **Learning:** Icon-only action buttons (like Delete) in nested lists or trees without the item's context in the aria-label are ambiguous to screen reader users.
 **Action:** When adding icon-only action buttons to items in lists, always include the specific item's title in the `aria-label` (e.g., `aria-label="Delete task: [Task Title]"`) to provide explicit context.
+## 2026-09-07 - View Mode Toggle Button Group Accessibility\n**Learning:** View mode toggle groups constructed with basic buttons and styled divs lack semantic structure, leaving screen reader and keyboard users without context on the current view or clear focus indication.\n**Action:** For custom view toggle groups, use `role="group"`, add an `aria-label` on the container, use `type="button"` and `aria-pressed` on individual buttons, and apply `focus-visible` utility classes for clear keyboard focus states.

--- a/src/components/TaskSection.tsx
+++ b/src/components/TaskSection.tsx
@@ -287,10 +287,16 @@ export default function TaskSection({ selectedDate }: TaskSectionProps) {
           <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">Tasks</h2>
           
           {/* View Mode Toggle - Simplified and explicit */}
-          <div className="flex items-center ml-2 bg-gray-100 dark:bg-neutral-800 rounded-lg p-1 border border-gray-200 dark:border-neutral-700">
+          <div
+            role="group"
+            aria-label="View mode"
+            className="flex items-center ml-2 bg-gray-100 dark:bg-neutral-800 rounded-lg p-1 border border-gray-200 dark:border-neutral-700"
+          >
             <button
+              type="button"
+              aria-pressed={viewMode === 'list'}
               onClick={() => setViewMode('list')}
-              className={`px-3 py-1 rounded-md text-xs font-bold transition-all ${
+              className={`px-3 py-1 rounded-md text-xs font-bold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
                 viewMode === 'list' 
                   ? 'bg-blue-600 text-white shadow-sm' 
                   : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
@@ -299,8 +305,10 @@ export default function TaskSection({ selectedDate }: TaskSectionProps) {
               List
             </button>
             <button
+              type="button"
+              aria-pressed={viewMode === 'plan'}
               onClick={() => setViewMode('plan')}
-              className={`px-3 py-1 rounded-md text-xs font-bold transition-all ${
+              className={`px-3 py-1 rounded-md text-xs font-bold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
                 viewMode === 'plan' 
                   ? 'bg-blue-600 text-white shadow-sm' 
                   : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'


### PR DESCRIPTION
## What
Added accessibility attributes (`role="group"`, `aria-label`, `aria-pressed`, `type="button"`) and keyboard focus indicators (`focus-visible` styling) to the view mode toggle button group in the Task view.

## Why
Previously, the view mode toggle in the Task Section lacked semantic grouping, meaning screen readers couldn't announce the current selected state or context properly. Also, the buttons were lacking focus indicators, hindering keyboard navigation. This change ensures compliance with WCAG guidelines for button groups acting as a toggle and significantly improves the experience for keyboard and screen reader users.

## Before/After
- Before: `<div class="..."><button>List</button><button>Plan</button></div>`
- After: `<div role="group" aria-label="View mode" class="..."><button type="button" aria-pressed="true" class="... focus-visible:ring-2 ...">List</button>...</div>`

## Accessibility
- Added `role="group"` and `aria-label="View mode"` to provide explicit context for screen readers when navigating into the toggle group.
- Added `aria-pressed` to correctly communicate the active view mode state.
- Added explicit `type="button"` to avoid potential unintended form submissions if ever wrapped in a form.
- Added Tailwind `focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none` classes to provide a clear visual indicator during keyboard-only navigation.

---
*PR created automatically by Jules for task [1397546546045672476](https://jules.google.com/task/1397546546045672476) started by @aryankumar06*