### PR TITLE
🎨 Palette: [UX improvement] Add ARIA and Focus states to hierarchical tasks

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,6 @@
 ## 2026-06-08 - Explicit Context for Icon-Only Action Buttons in Lists
 **Learning:** Icon-only action buttons (like Delete) in nested lists or trees without the item's context in the aria-label are ambiguous to screen reader users.
 **Action:** When adding icon-only action buttons to items in lists, always include the specific item's title in the `aria-label` (e.g., `aria-label="Delete task: [Task Title]"`) to provide explicit context.
+## 2026-09-08 - Focus Visible Accessibility for Nested Toggles
+**Learning:** When using hierarchical lists with expand/collapse buttons or inline add actions, simple hover styles aren't enough. Screen readers need contextual `aria-label` (since icon-only or generic "Task" text lacks context), `aria-expanded` for disclosure widgets, and keyboard users need explicit focus indicators (e.g., `focus-visible:ring-2`).
+**Action:** Always add contextual `aria-label` (e.g. "Add task to project: [name]") and `focus-visible:ring-2` outline classes to interactive UI elements in deeply nested lists.

--- a/src/components/ui/agent-plan.tsx
+++ b/src/components/ui/agent-plan.tsx
@@ -242,7 +242,9 @@ export default function Plan() {
                   {hasChildren && (
                     <button
                       onClick={() => toggleExpand(project.id)}
-                      className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+                      aria-expanded={isExpanded}
+                      aria-label={`${isExpanded ? 'Collapse' : 'Expand'} project: ${project.name}`}
+                      className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                     >
                       {isExpanded ? <ChevronDown className="w-5 h-5" /> : <ChevronRight className="w-5 h-5" />}
                     </button>
@@ -307,7 +309,8 @@ export default function Plan() {
                   {/* Add Task Button */}
                   <button
                     onClick={() => setAddingTaskTo(project.id)}
-                    className="flex items-center gap-1 px-3 py-1 text-xs bg-blue-600 hover:bg-blue-700 text-white rounded-md transition-colors"
+                    aria-label={`Add task to project: ${project.name}`}
+                    className="flex items-center gap-1 px-3 py-1 text-xs bg-blue-600 hover:bg-blue-700 text-white rounded-md transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-neutral-800"
                   >
                     <Plus className="w-3 h-3" />
                     Add Task
@@ -373,7 +376,9 @@ export default function Plan() {
                               {hasSubtasks && (
                                 <button
                                   onClick={() => toggleExpand(task.id)}
-                                  className="text-gray-400 hover:text-gray-600"
+                                  aria-expanded={isTaskExpanded}
+                                  aria-label={`${isTaskExpanded ? 'Collapse' : 'Expand'} task: ${task.title}`}
+                                  className="text-gray-400 hover:text-gray-600 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                                 >
                                   {isTaskExpanded ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
                                 </button>
@@ -426,7 +431,8 @@ export default function Plan() {
                               {/* Add Subtask Button */}
                               <button
                                 onClick={() => setAddingSubtaskTo(task.id)}
-                                className="flex items-center gap-1 px-2 py-1 text-xs bg-green-600 hover:bg-green-700 text-white rounded-md"
+                                aria-label={`Add subtask to task: ${task.title}`}
+                                className="flex items-center gap-1 px-2 py-1 text-xs bg-green-600 hover:bg-green-700 text-white rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-neutral-800"
                               >
                                 <Plus className="w-3 h-3" />
                                 Subtask

--- a/src/components/ui/task-plan.tsx
+++ b/src/components/ui/task-plan.tsx
@@ -176,7 +176,9 @@ export default function TaskPlan({
                     {task.subtasks.length > 0 && (
                       <button
                         onClick={() => toggleTaskExpansion(task.id)}
-                        className="mr-1 p-0.5 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+                        aria-expanded={isExpanded}
+                        aria-label={`${isExpanded ? 'Collapse' : 'Expand'} task: ${task.title}`}
+                        className="mr-1 p-0.5 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                       >
                         {isExpanded ? (
                           <ChevronDown className="w-4 h-4" />


### PR DESCRIPTION
**What:** 
Added explicit `aria-expanded`, contextual `aria-label`, and keyboard focus (`focus-visible:ring-2`) classes to multiple icon-only utility buttons within the hierarchical `agent-plan.tsx` and `task-plan.tsx` components.

**Why:** 
Previously, these disclosure widgets and inline add actions relied solely on hover states and lacked contextual labels. This made keyboard navigation difficult to track and provided unhelpful announcements to screen reader users (e.g. just reading generic "task" or nothing for icon-only tags in nested structures).

**Before/After:** 
Before: Interactive expand and add buttons did not highlight clearly on Tab focus. Screen readers lacked context on which exact task or project an action was bound to.
After: Buttons now display a clear blue/green focus ring when navigating via keyboard. Screen readers will now hear explicit context like "Expand project: Website Redesign" or "Add task to project: App Launch". 

**Accessibility:** 
- Added `aria-expanded` properties tracking open/closed states.
- Replaced ambiguous generic context by interpolating project/task names into descriptive `aria-label` tags. 
- Integrated standard Tailwind `focus-visible:outline-none focus-visible:ring-2` to support explicit keyboard focus tracking.

---
*PR created automatically by Jules for task [3196818374689389624](https://jules.google.com/task/3196818374689389624) started by @aryankumar06*