### PR TITLE
🎨 Palette: Enhance project form accessibility

### DIFF
--- a/src/components/DittoDashboard.tsx
+++ b/src/components/DittoDashboard.tsx
@@ -44,7 +44,9 @@ export default function DittoDashboard() {
       <div className="mb-6 flex items-center justify-end">
         <button
           onClick={() => setShowAddForm(!showAddForm)}
-          className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors font-medium"
+          aria-expanded={showAddForm}
+          aria-controls="add-project-form"
+          className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
         >
           <Plus className="w-4 h-4" />
           {showAddForm ? 'Cancel' : 'Add Project'}
@@ -55,6 +57,7 @@ export default function DittoDashboard() {
       <AnimatePresence>
         {showAddForm && (
           <motion.div
+            id="add-project-form"
             initial={{ opacity: 0, height: 0 }}
             animate={{ opacity: 1, height: 'auto' }}
             exit={{ opacity: 0, height: 0 }}
@@ -96,15 +99,17 @@ export default function DittoDashboard() {
                 </div>
 
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                  <label id="priority-group-label" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                     Priority
                   </label>
-                  <div className="flex gap-2">
+                  <div role="group" aria-labelledby="priority-group-label" className="flex gap-2">
                     {(['low', 'medium', 'high'] as const).map((priority) => (
                       <button
                         key={priority}
+                        type="button"
+                        aria-pressed={newProjectPriority === priority}
                         onClick={() => setNewProjectPriority(priority)}
-                        className={`px-4 py-2 rounded-lg font-medium transition-colors ${
+                        className={`px-4 py-2 rounded-lg font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
                           newProjectPriority === priority
                             ? priority === 'high'
                               ? 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
@@ -122,15 +127,17 @@ export default function DittoDashboard() {
 
                 <div className="flex gap-3 pt-2">
                   <button
+                    type="button"
                     onClick={handleAddProject}
                     disabled={!newProjectTitle.trim()}
-                    className="px-6 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed text-white rounded-lg transition-colors font-medium"
+                    className="px-6 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed text-white rounded-lg transition-colors font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                   >
                     Create Project
                   </button>
                   <button
+                    type="button"
                     onClick={() => setShowAddForm(false)}
-                    className="px-6 py-2 bg-gray-200 hover:bg-gray-300 dark:bg-neutral-700 dark:hover:bg-neutral-600 text-gray-700 dark:text-gray-300 rounded-lg transition-colors font-medium"
+                    className="px-6 py-2 bg-gray-200 hover:bg-gray-300 dark:bg-neutral-700 dark:hover:bg-neutral-600 text-gray-700 dark:text-gray-300 rounded-lg transition-colors font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                   >
                     Cancel
                   </button>


### PR DESCRIPTION
### 💡 What
Added comprehensive accessibility enhancements to the Add Project form in `DittoDashboard`. This includes semantic ARIA attributes for the expanding section, explicit grouping for the priority selector, defined button types, and visible keyboard focus states.

### 🎯 Why
These changes ensure the form is fully accessible to screen reader users (by explicitly announcing expanding states and button groups) and keyboard navigators (by providing clear focus indicators). It solves potential usability issues for users relying on assistive technologies. Adding `type="button"` also acts as a defensive measure against accidental form submissions if the component structure changes in the future.

### 📸 Before/After
- **Before**: The "Add Project" button lacked state indicators, the priority buttons were not grouped semantically, and interactive elements relied only on default focus styles which could be indistinct.
- **After**: The "Add Project" button now uses `aria-expanded` and controls a designated ID. The priority selector is explicitly a `group` with `aria-pressed` states. All buttons have clear `focus-visible:ring-2` indicators for better keyboard tracking. 
*(No persistent visual changes to the layout.)*

### ♿ Accessibility
- Added `aria-expanded` and `aria-controls` to the disclosure widget.
- Added `role="group"` and `aria-labelledby` to the custom priority selector.
- Added `aria-pressed` to the priority toggle buttons.
- Added `type="button"` to non-submit buttons.
- Added explicit `focus-visible:ring-2` utility classes for keyboard focus visibility.

---
*PR created automatically by Jules for task [18022187129472739800](https://jules.google.com/task/18022187129472739800) started by @aryankumar06*